### PR TITLE
fix: include underscores in project hash generation

### DIFF
--- a/magnus-process.el
+++ b/magnus-process.el
@@ -488,9 +488,9 @@ Kills the current process and respawns in the new directory."
 
 (defun magnus-process--project-hash (directory)
   "Convert DIRECTORY to Claude's project hash format.
-Replaces slashes, spaces, and tildes with hyphens."
+Replaces slashes, spaces, tildes, and underscores with hyphens."
   (let ((path (directory-file-name (expand-file-name directory))))
-    (replace-regexp-in-string "[/ ~]+" "-" path)))
+    (replace-regexp-in-string "[/ ~_]+" "-" path)))
 
 (defun magnus-process--spawn-with-session (instance &optional session-id)
   "Spawn a Claude Code process for INSTANCE, optionally resuming SESSION-ID."


### PR DESCRIPTION
All my instances were missing session ID and I couldn't resurrect them. This fixes the problem.

Claude Code replaces underscores with hyphens in its project hash directory names (e.g., ~/.claude/projects/-home-user-project-name). Magnus was only replacing slashes, spaces, and tildes, which caused it to look in the wrong directory for session data when the project path contained underscores. This prevented session ID capture and agent resurrection.