### PR TITLE
Add Codex as a Magnus provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,6 @@ jobs:
 
       - name: Lint
         run: make lint
+
+      - name: Test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
 EMACS ?= emacs
 EL_FILES ?= $(wildcard *.el)
 
-.PHONY: lint lint-compile clean
+.PHONY: lint lint-compile test clean
 
 lint:
 	@$(EMACS) --batch -L . -l lint.el -- $(EL_FILES)
 
 lint-compile:
 	@$(EMACS) --batch -L . -l lint.el -- --compile $(EL_FILES)
+
+test:
+	@$(EMACS) --batch -Q -L . -L test \
+		--eval "(setq load-prefer-newer t)" \
+		-l test/magnus-provider-tests.el -f ert-run-tests-batch-and-exit
 
 clean:
 	rm -f *.elc

--- a/README.md
+++ b/README.md
@@ -107,9 +107,12 @@ A per-project scratch buffer where you can paste notes, links, Confluence pages,
 - Persists across Emacs sessions (stored in `~/.emacs.d/magnus-context/`)
 
 ### Thinking Trace
-Press `t` on any instance to open a trace buffer that reads the session JSONL file directly. See the full thinking/reasoning that's normally collapsed in Claude Code, plus user messages and responses — in a regular scrollable Emacs buffer.
+Press `t` on any instance to open a trace buffer that reads its provider's
+session JSONL directly. Claude traces include its recorded thinking blocks;
+Codex traces include visible `[thinking]` engineering journals, user messages,
+and responses. Codex's encrypted internal reasoning is deliberately not shown.
 
-The trace auto-refreshes every 2 seconds so you can watch agents think in real-time.
+The trace auto-refreshes so you can watch agents work in real time.
 
 ### Direct Messaging
 Press `m` to send a message directly to an agent from the status buffer. The message appears in the agent's terminal as if you typed it — Claude acts on it immediately. Agents also receive periodic reminders (every 10 min) that rotate through different messages — nudging them to check the coordination file, share discoveries, and update their status.

--- a/README.md
+++ b/README.md
@@ -48,21 +48,27 @@ This requires a `codex` executable with managed App Server support (`codex
 app-server daemon` and `codex app-server proxy`). Customize its path with
 `magnus-codex-executable`. Magnus starts or reuses one idle shared daemon. A
 small per-instance observer connects to that daemon through the local Unix
-socket while the TUI connects to the same thread with `--remote unix://`.
-The observer handles identity, lifecycle, status events, and persisted thread
-IDs; it never writes interactive turns or terminal output.
+socket. For a new agent, the observer creates and subscribes to the thread,
+persists the returned ID, and then launches the TUI to resume that exact thread
+with `--remote unix://`. Existing agents are subscribed by the observer before
+their TUI is resumed. This keeps identity, lifecycle events, interruption, and
+resurrection connection-scoped without making the observer an interactive
+writer. A custom `magnus-codex-remote` must be a local `unix://` endpoint so
+the observer and TUI cannot accidentally connect to different servers.
 
 Inside a Codex buffer, use the TUI exactly as you would in a terminal: type at
 its composer, answer approvals in its native UI, and use Magnus's `C-g`
 binding to send Escape. Direct messages and coordination nudges are typed into
-that same vterm, making the TUI the sole interactive writer; Codex therefore
-owns the semantics of input received during an active turn. Archiving stops
-only the TUI and observer, not the shared daemon. Revisiting an archived agent
-resumes its persisted thread in a fresh TUI.
+that same vterm through a FIFO, making the TUI the sole interactive writer;
+Codex therefore owns the semantics of input received during an active turn.
+Magnus holds automated delivery while you are actively in that TUI to avoid
+interfering with its composer. Archiving first requests interruption of any
+observed active turn, then stops the TUI and observer but not the shared daemon.
+Revisiting an archived agent resumes its persisted thread in a fresh TUI.
 
-New Codex TUI launches are serialized only for the brief moment in which
-Magnus captures each TUI-created thread ID. After that handoff, the agents run
-independently. Magnus also adapts its full onboarding philosophy for Codex:
+Codex observer startup has a bounded timeout, and different agents may launch
+independently because each observer receives its own `thread/start` response.
+Magnus also adapts its full onboarding philosophy for Codex:
 named identity, first-person memory, coordination claims and discoveries,
 attention etiquette, debriefing, and candid `[thinking]`/`[response]`
 engineering journals. New Codex threads receive this as a visible first-turn
@@ -215,6 +221,13 @@ Or in your config:
 ```elisp
 (quelpa '(magnus :fetcher github :repo "hrishikeshs/magnus"))
 ```
+
+After upgrading Magnus in a running Emacs—through `M-x magnus-upgrade`,
+package-menu, package-vc, straight, or another package manager—restart Emacs
+before opening Magnus again. This prevents already-loaded functions and
+instance structures from being mixed with the newly installed package version.
+`magnus-upgrade` enforces this restart for upgrades initiated by versions that
+include the guard.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Spawn, kill, suspend/resume, rename, and switch between Claude Code instances ru
 Run `M-x magnus-create-codex` to create a Codex instance through Codex App
 Server. Codex is strictly opt-in: existing commands, saved state, vterm
 behavior, and Claude storage paths remain unchanged. Codex instances support
-thread resume, streamed messages and plans, same-turn steering, interruption,
+thread resume, streamed messages and plans, explicit steering, interruption,
 and semantic approval callbacks. They are labeled `[codex]` in the status
 buffer.
 
@@ -49,9 +49,14 @@ This requires a `codex` executable with `codex app-server` support. Customize
 its path with `magnus-codex-executable`. App Server connections use stdio and
 are restarted transparently when a saved Codex thread is revisited.
 
-Inside a Codex buffer, press `m` to send or steer, `a` to answer a pending
-command/file approval, and `C-c C-k` to interrupt the active turn. Magnus also
-adapts its full onboarding philosophy for Codex: named identity, first-person
+Inside a Codex buffer, press `m` to send, `a` to answer a pending command/file
+approval, and `C-c C-k` to interrupt the active turn. Messages received while
+a turn is active queue for the next turn by default, matching Claude/vterm
+behavior and preventing a casual coordination nudge from redirecting work in
+progress. Set `magnus-codex-active-turn-delivery` to `steer` for immediate
+turn/steer injection; explicit calls to `magnus-codex-steer` always steer.
+Magnus also adapts its full onboarding philosophy for Codex: named identity,
+first-person
 memory, coordination claims and discoveries, attention etiquette, debriefing,
 and candid `[thinking]`/`[response]` engineering journals. Claude's established
 prompt remains unchanged.

--- a/README.md
+++ b/README.md
@@ -38,42 +38,28 @@ Spawn, kill, suspend/resume, rename, and switch between Claude Code instances ru
 
 ### Optional Codex Instances
 
-Run `M-x magnus-create-codex` to create a Codex instance through Codex App
-Server. Codex is strictly opt-in: existing commands, saved state, Claude
-behavior, and Claude storage paths remain unchanged. Each Codex instance runs
-the full native Codex TUI in a vterm buffer and is labeled `[codex]` in the
-status buffer.
-
-This requires a `codex` executable with managed App Server support (`codex
-app-server daemon` and `codex app-server proxy`). Customize its path with
-`magnus-codex-executable`. Magnus starts or reuses one idle shared daemon. A
-small per-instance observer connects to that daemon through the local Unix
-socket. For a new agent, the observer creates and subscribes to the thread,
-persists the returned ID, and then launches the TUI to resume that exact thread
-with `--remote unix://`. Existing agents are subscribed by the observer before
-their TUI is resumed. This keeps identity, lifecycle events, interruption, and
-resurrection connection-scoped without making the observer an interactive
-writer. A custom `magnus-codex-remote` must be a local `unix://` endpoint so
-the observer and TUI cannot accidentally connect to different servers.
+Run `M-x magnus-create-codex` to create a Codex instance. Codex is strictly
+opt-in: existing commands, saved state, Claude behavior, and Claude storage
+paths remain unchanged. Each Codex instance runs the full native Codex TUI in
+a vterm buffer and is labeled `[codex]` in the status buffer. Only the `codex`
+executable is required; customize its path with `magnus-codex-executable`.
 
 Inside a Codex buffer, use the TUI exactly as you would in a terminal: type at
 its composer, answer approvals in its native UI, and use Magnus's `C-g`
 binding to send Escape. Direct messages and coordination nudges are typed into
-that same vterm through a FIFO, making the TUI the sole interactive writer;
-Codex therefore owns the semantics of input received during an active turn.
-Magnus holds automated delivery while you are actively in that TUI to avoid
-interfering with its composer. Archiving first requests interruption of any
-observed active turn, then stops the TUI and observer but not the shared daemon.
-Revisiting an archived agent resumes its persisted thread in a fresh TUI.
+that same vterm through a serialized queue, making the TUI the only session
+owner. Magnus holds automated delivery while you are actively in that TUI to
+avoid interfering with its composer. Archiving interrupts and closes the TUI;
+revisiting the agent resumes its persisted session in a fresh one.
 
-Codex observer startup has a bounded timeout, and different agents may launch
-independently because each observer receives its own `thread/start` response.
-Magnus also adapts its full onboarding philosophy for Codex:
-named identity, first-person memory, coordination claims and discoveries,
-attention etiquette, debriefing, and candid `[thinking]`/`[response]`
-engineering journals. New Codex threads receive this as a visible first-turn
-onboarding message so it persists in their history across resurrection.
-Claude's established prompt remains unchanged.
+For a new agent, Magnus correlates its unique onboarding prompt with the new
+local Codex rollout record and saves that session ID. Concurrent launches are
+matched by their prompt rather than by whichever file is newest. Capture is
+bounded and fail-safe: if Codex's local record cannot be identified, the live
+TUI remains usable, but that session cannot be resurrected automatically.
+Magnus's onboarding includes named identity, first-person memory, coordination
+etiquette, and candid `[thinking]`/`[response]` engineering journals. Claude's
+established prompt remains unchanged.
 
 ### Agent Coordination
 Agents communicate through a shared `.magnus-coord.md` file:
@@ -177,7 +163,7 @@ Everything persists across Emacs sessions:
 - Emacs 28.1+
 - [vterm](https://github.com/akermu/emacs-libvterm)
 - [transient](https://github.com/magit/transient) (built into Emacs 28+)
-- Codex CLI with App Server support (only for opt-in Codex instances)
+- Codex CLI (only for opt-in Codex instances)
 
 ## Installation
 
@@ -377,7 +363,7 @@ Magnus avoids triggering interactive Helm/Projectile prompts when creating insta
 ;; Path to claude executable (default: "claude")
 (setq magnus-claude-executable "/path/to/claude")
 
-;; Path to codex executable for optional App Server instances
+;; Path to codex executable for optional native TUI instances
 (setq magnus-codex-executable "/path/to/codex")
 
 ;; Default directory for new instances
@@ -430,7 +416,7 @@ magnus/
 ├── magnus-persistence.el  # Save/restore state across sessions
 ├── magnus-process.el      # Process management (vterm + headless)
 ├── magnus-provider.el     # Additive provider dispatch
-├── magnus-provider-codex.el # Optional Codex App Server provider
+├── magnus-provider-codex.el # Optional native Codex TUI provider
 ├── magnus-trace.el        # Thinking trace JSONL viewer
 ├── magnus-status.el       # Status buffer UI
 ├── magnus-transient.el    # Transient popup menus

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ This requires a `codex` executable with `codex app-server` support. Customize
 its path with `magnus-codex-executable`. App Server connections use stdio and
 are restarted transparently when a saved Codex thread is revisited.
 
-Inside a Codex buffer, press `m` to send, `a` to answer a pending command/file
-approval, and `C-c C-k` to interrupt the active turn. Messages received while
+Inside a Codex buffer, type directly at the `> ` prompt and press `RET` to
+send. Use `C-c a` to answer a pending command/file approval, `C-c m` for
+minibuffer-based message entry, and `C-c C-k` to interrupt the active turn.
+Messages received while
 a turn is active queue for the next turn by default, matching Claude/vterm
 behavior and preventing a casual coordination nudge from redirecting work in
 progress. Set `magnus-codex-active-turn-delivery` to `steer` for immediate

--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ Magnus solves all of this.
 ### Instance Management
 Spawn, kill, suspend/resume, rename, and switch between Claude Code instances running in vterm buffers. Each instance gets a randomly generated name (like `swift-fox` or `keen-owl`) and runs in its own terminal. Change an instance's working directory with session resume — Claude keeps its full conversation history.
 
+### Optional Codex Instances
+
+Run `M-x magnus-create-codex` to create a Codex instance through Codex App
+Server. Codex is strictly opt-in: existing commands, saved state, vterm
+behavior, and Claude storage paths remain unchanged. Codex instances support
+thread resume, streamed messages and plans, same-turn steering, interruption,
+and semantic approval callbacks. They are labeled `[codex]` in the status
+buffer.
+
+This requires a `codex` executable with `codex app-server` support. Customize
+its path with `magnus-codex-executable`. App Server connections use stdio and
+are restarted transparently when a saved Codex thread is revisited.
+
+Inside a Codex buffer, press `m` to send or steer, `a` to answer a pending
+command/file approval, and `C-c C-k` to interrupt the active turn. Magnus also
+adapts its full onboarding philosophy for Codex: named identity, first-person
+memory, coordination claims and discoveries, attention etiquette, debriefing,
+and candid `[thinking]`/`[response]` engineering journals. Claude's established
+prompt remains unchanged.
+
 ### Agent Coordination
 Agents communicate through a shared `.magnus-coord.md` file:
 
@@ -138,6 +158,7 @@ Everything persists across Emacs sessions:
 - Emacs 28.1+
 - [vterm](https://github.com/akermu/emacs-libvterm)
 - [transient](https://github.com/magit/transient) (built into Emacs 28+)
+- Codex CLI with App Server support (only for opt-in Codex instances)
 
 ## Installation
 
@@ -330,6 +351,9 @@ Magnus avoids triggering interactive Helm/Projectile prompts when creating insta
 ;; Path to claude executable (default: "claude")
 (setq magnus-claude-executable "/path/to/claude")
 
+;; Path to codex executable for optional App Server instances
+(setq magnus-codex-executable "/path/to/codex")
+
 ;; Default directory for new instances
 (setq magnus-default-directory "~/projects")
 
@@ -379,6 +403,8 @@ magnus/
 ├── magnus-instances.el    # Instance data structure and registry
 ├── magnus-persistence.el  # Save/restore state across sessions
 ├── magnus-process.el      # Process management (vterm + headless)
+├── magnus-provider.el     # Additive provider dispatch
+├── magnus-provider-codex.el # Optional Codex App Server provider
 ├── magnus-trace.el        # Thinking trace JSONL viewer
 ├── magnus-status.el       # Status buffer UI
 ├── magnus-transient.el    # Transient popup menus

--- a/README.md
+++ b/README.md
@@ -39,29 +39,35 @@ Spawn, kill, suspend/resume, rename, and switch between Claude Code instances ru
 ### Optional Codex Instances
 
 Run `M-x magnus-create-codex` to create a Codex instance through Codex App
-Server. Codex is strictly opt-in: existing commands, saved state, vterm
-behavior, and Claude storage paths remain unchanged. Codex instances support
-thread resume, streamed messages and plans, explicit steering, interruption,
-and semantic approval callbacks. They are labeled `[codex]` in the status
-buffer.
+Server. Codex is strictly opt-in: existing commands, saved state, Claude
+behavior, and Claude storage paths remain unchanged. Each Codex instance runs
+the full native Codex TUI in a vterm buffer and is labeled `[codex]` in the
+status buffer.
 
-This requires a `codex` executable with `codex app-server` support. Customize
-its path with `magnus-codex-executable`. App Server connections use stdio and
-are restarted transparently when a saved Codex thread is revisited.
+This requires a `codex` executable with managed App Server support (`codex
+app-server daemon` and `codex app-server proxy`). Customize its path with
+`magnus-codex-executable`. Magnus starts or reuses one idle shared daemon. A
+small per-instance observer connects to that daemon through the local Unix
+socket while the TUI connects to the same thread with `--remote unix://`.
+The observer handles identity, lifecycle, status events, and persisted thread
+IDs; it never writes interactive turns or terminal output.
 
-Inside a Codex buffer, type directly at the `> ` prompt and press `RET` to
-send. Use `C-c a` to answer a pending command/file approval, `C-c m` for
-minibuffer-based message entry, and `C-c C-k` to interrupt the active turn.
-Messages received while
-a turn is active queue for the next turn by default, matching Claude/vterm
-behavior and preventing a casual coordination nudge from redirecting work in
-progress. Set `magnus-codex-active-turn-delivery` to `steer` for immediate
-turn/steer injection; explicit calls to `magnus-codex-steer` always steer.
-Magnus also adapts its full onboarding philosophy for Codex: named identity,
-first-person
-memory, coordination claims and discoveries, attention etiquette, debriefing,
-and candid `[thinking]`/`[response]` engineering journals. Claude's established
-prompt remains unchanged.
+Inside a Codex buffer, use the TUI exactly as you would in a terminal: type at
+its composer, answer approvals in its native UI, and use Magnus's `C-g`
+binding to send Escape. Direct messages and coordination nudges are typed into
+that same vterm, making the TUI the sole interactive writer; Codex therefore
+owns the semantics of input received during an active turn. Archiving stops
+only the TUI and observer, not the shared daemon. Revisiting an archived agent
+resumes its persisted thread in a fresh TUI.
+
+New Codex TUI launches are serialized only for the brief moment in which
+Magnus captures each TUI-created thread ID. After that handoff, the agents run
+independently. Magnus also adapts its full onboarding philosophy for Codex:
+named identity, first-person memory, coordination claims and discoveries,
+attention etiquette, debriefing, and candid `[thinking]`/`[response]`
+engineering journals. New Codex threads receive this as a visible first-turn
+onboarding message so it persists in their history across resurrection.
+Claude's established prompt remains unchanged.
 
 ### Agent Coordination
 Agents communicate through a shared `.magnus-coord.md` file:

--- a/lint.el
+++ b/lint.el
@@ -15,9 +15,10 @@
       (let ((arg (pop args)))
         (cond
          ((string= arg "--compile")
-          (setq lint-do-compile t)
+         (setq lint-do-compile t)
           ;; Initialize package.el so installed deps (vterm, transient)
           ;; are on the load-path for byte-compilation.
+          (setq load-prefer-newer t)
           (require 'package)
           (package-initialize))
          ((string-suffix-p ".el" arg) (push arg files)))))

--- a/magnus-coord.el
+++ b/magnus-coord.el
@@ -18,6 +18,7 @@
 ;;; Code:
 
 (require 'magnus-instances)
+(require 'magnus-provider)
 
 (declare-function vterm-send-string "vterm")
 (declare-function project-root "project")
@@ -178,31 +179,37 @@ This prevents partial reads when agents write concurrently."
   "Hash of instance-id → timestamp of last Magnus system nudge.")
 
 (defun magnus-coord-nudge-agent (instance message &optional source)
-  "Nudge INSTANCE by sending MESSAGE to its vterm buffer.
+  "Nudge INSTANCE by sending MESSAGE through its provider.
 When SOURCE is non-nil, prepend \"[From SOURCE]:\" to distinguish
 system messages from user-typed input.  System messages from Magnus
 are debounced per `magnus-coord-nudge-debounce'."
   (catch 'magnus-debounced
-  (let ((id (magnus-instance-id instance)))
-    (when (and (string= source "Magnus")
-               magnus-coord-nudge-debounce)
-      (let ((last (gethash id magnus-coord--last-nudge 0)))
-        (when (< (- (float-time) last) magnus-coord-nudge-debounce)
-          (throw 'magnus-debounced nil))))
-    (when-let ((buffer (magnus-instance-buffer instance)))
-      (when (buffer-live-p buffer)
-        (let ((text (if source
-                        (format "[From %s]: %s" source message)
-                      message)))
-          (when (string= source "Magnus")
-            (puthash id (float-time) magnus-coord--last-nudge))
-          (with-current-buffer buffer
-            (vterm-send-string text)
-            (run-with-timer 0.1 nil
-                            (lambda ()
-                              (when (buffer-live-p buffer)
-                                (with-current-buffer buffer
-                                  (vterm-send-return))))))))))))
+    (let ((id (magnus-instance-id instance)))
+      (when (and (string= source "Magnus")
+                 magnus-coord-nudge-debounce)
+        (let ((last (gethash id magnus-coord--last-nudge 0)))
+          (when (< (- (float-time) last) magnus-coord-nudge-debounce)
+            (throw 'magnus-debounced nil))))
+      (let ((text (if source
+                      (format "[From %s]: %s" source message)
+                    message)))
+        (if (magnus-provider-external-p instance)
+            (progn
+              (when (string= source "Magnus")
+                (puthash id (float-time) magnus-coord--last-nudge))
+              (magnus-provider-call instance 'send text))
+          (when-let ((buffer (magnus-instance-buffer instance)))
+            (when (buffer-live-p buffer)
+              (when (string= source "Magnus")
+                (puthash id (float-time) magnus-coord--last-nudge))
+              (with-current-buffer buffer
+                (vterm-send-string text)
+                (run-with-timer
+                 0.1 nil
+                 (lambda ()
+                   (when (buffer-live-p buffer)
+                     (with-current-buffer buffer
+                       (vterm-send-return)))))))))))))
 
 
 ;;; Periodic reminders

--- a/magnus-coord.el
+++ b/magnus-coord.el
@@ -23,6 +23,7 @@
 (declare-function vterm-send-string "vterm")
 (declare-function project-root "project")
 (declare-function vterm-send-return "vterm")
+(declare-function magnus-process-running-p "magnus-process")
 
 (defvar magnus-claude-executable)
 (declare-function magnus--headless-command "magnus")
@@ -178,6 +179,23 @@ This prevents partial reads when agents write concurrently."
 (defvar magnus-coord--last-nudge (make-hash-table :test 'equal)
   "Hash of instance-id → timestamp of last Magnus system nudge.")
 
+(defun magnus-coord--log-undelivered-nudge (instance text reason)
+  "Record that TEXT could not reach INSTANCE because of REASON."
+  (let* ((name (magnus-instance-name instance))
+         (directory (magnus-instance-directory instance))
+         (safe-text (replace-regexp-in-string
+                     "@" "(at) "
+                     (replace-regexp-in-string "[\n\r]+" " " text)))
+         (entry (format "Undelivered nudge to %s (%s): %s"
+                        name reason safe-text)))
+    (condition-case err
+        (magnus-coord-add-log directory "Magnus" entry)
+      (error
+       (message "Magnus: could not log undelivered nudge for %s: %s"
+                name (error-message-string err))))
+    (message "Magnus: %s" entry)
+    nil))
+
 (defun magnus-coord-nudge-agent (instance message &optional source)
   "Nudge INSTANCE by sending MESSAGE through its provider.
 When SOURCE is non-nil, prepend \"[From SOURCE]:\" to distinguish
@@ -193,23 +211,28 @@ are debounced per `magnus-coord-nudge-debounce'."
       (let ((text (if source
                       (format "[From %s]: %s" source message)
                     message)))
-        (if (magnus-provider-external-p instance)
-            (progn
+        (condition-case err
+            (if (not (magnus-process-running-p instance))
+                (magnus-coord--log-undelivered-nudge
+                 instance text "not running")
+              (if (magnus-provider-external-p instance)
+                  (magnus-provider-call instance 'send text)
+                (let ((buffer (magnus-instance-buffer instance)))
+                  (unless (buffer-live-p buffer)
+                    (error "agent buffer is not live"))
+                  (with-current-buffer buffer
+                    (vterm-send-string text)
+                    (run-with-timer
+                     0.1 nil
+                     (lambda ()
+                       (when (buffer-live-p buffer)
+                         (with-current-buffer buffer
+                           (vterm-send-return))))))))
               (when (string= source "Magnus")
-                (puthash id (float-time) magnus-coord--last-nudge))
-              (magnus-provider-call instance 'send text))
-          (when-let ((buffer (magnus-instance-buffer instance)))
-            (when (buffer-live-p buffer)
-              (when (string= source "Magnus")
-                (puthash id (float-time) magnus-coord--last-nudge))
-              (with-current-buffer buffer
-                (vterm-send-string text)
-                (run-with-timer
-                 0.1 nil
-                 (lambda ()
-                   (when (buffer-live-p buffer)
-                     (with-current-buffer buffer
-                       (vterm-send-return)))))))))))))
+                (puthash id (float-time) magnus-coord--last-nudge)))
+          (error
+           (magnus-coord--log-undelivered-nudge
+            instance text (error-message-string err))))))))
 
 
 ;;; Periodic reminders

--- a/magnus-coord.el
+++ b/magnus-coord.el
@@ -23,7 +23,6 @@
 (declare-function vterm-send-string "vterm")
 (declare-function project-root "project")
 (declare-function vterm-send-return "vterm")
-(declare-function magnus-process-running-p "magnus-process")
 
 (defvar magnus-claude-executable)
 (declare-function magnus--headless-command "magnus")
@@ -196,6 +195,17 @@ This prevents partial reads when agents write concurrently."
     (message "Magnus: %s" entry)
     nil))
 
+(defun magnus-coord--instance-running-p (instance)
+  "Return non-nil when INSTANCE can currently receive a nudge.
+This intentionally avoids requiring `magnus-process', which itself requires
+this module and would create a load-order cycle for standalone callers."
+  (if (magnus-provider-external-p instance)
+      (magnus-provider-call instance 'running-p)
+    (when-let ((buffer (magnus-instance-buffer instance)))
+      (and (buffer-live-p buffer)
+           (get-buffer-process buffer)
+           (process-live-p (get-buffer-process buffer))))))
+
 (defun magnus-coord-nudge-agent (instance message &optional source)
   "Nudge INSTANCE by sending MESSAGE through its provider.
 When SOURCE is non-nil, prepend \"[From SOURCE]:\" to distinguish
@@ -212,7 +222,7 @@ are debounced per `magnus-coord-nudge-debounce'."
                       (format "[From %s]: %s" source message)
                     message)))
         (condition-case err
-            (if (not (magnus-process-running-p instance))
+            (if (not (magnus-coord--instance-running-p instance))
                 (magnus-coord--log-undelivered-nudge
                  instance text "not running")
               (if (magnus-provider-external-p instance)

--- a/magnus-health.el
+++ b/magnus-health.el
@@ -9,8 +9,8 @@
 
 ;;; Commentary:
 
-;; This module monitors the health of Claude Code instances by hashing
-;; buffer content and detecting stale, stuck, or dead agents.  Health
+;; This module monitors the health of provider-backed instances by hashing
+;; their display buffer and detecting stale, stuck, or dead agents.  Health
 ;; status is displayed in the magnus status buffer.
 
 ;;; Code:

--- a/magnus-instances.el
+++ b/magnus-instances.el
@@ -24,11 +24,11 @@
   (id nil :documentation "Unique identifier (UUID string).")
   (name nil :documentation "User-friendly name.")
   (directory nil :documentation "Working directory.")
-  (buffer nil :documentation "The vterm buffer running claude.")
+  (buffer nil :documentation "The display buffer running the agent.")
   (created-at nil :documentation "Creation timestamp.")
   (provider 'claude :documentation "Agent provider symbol (defaults to `claude').")
   (status 'stopped :documentation "Status: running, stopped, suspended, purged.")
-  (session-id nil :documentation "Claude Code session ID for this instance.")
+  (session-id nil :documentation "Provider session ID for this instance.")
   (previous-session-id nil :documentation "Session ID before last directory change.")
   (purged-at nil :documentation "Timestamp when instance was archived (purged)."))
 

--- a/magnus-instances.el
+++ b/magnus-instances.el
@@ -10,7 +10,7 @@
 ;;; Commentary:
 
 ;; This module provides the data structures and functions for managing
-;; the registry of Claude Code instances.
+;; the registry of agent instances.
 
 ;;; Code:
 
@@ -20,12 +20,13 @@
 
 (cl-defstruct (magnus-instance (:constructor magnus-instance--create)
                                (:copier nil))
-  "A Claude Code instance."
+  "An agent instance managed by Magnus."
   (id nil :documentation "Unique identifier (UUID string).")
   (name nil :documentation "User-friendly name.")
   (directory nil :documentation "Working directory.")
   (buffer nil :documentation "The vterm buffer running claude.")
   (created-at nil :documentation "Creation timestamp.")
+  (provider 'claude :documentation "Agent provider symbol (defaults to `claude').")
   (status 'stopped :documentation "Status: running, stopped, suspended, purged.")
   (session-id nil :documentation "Claude Code session ID for this instance.")
   (previous-session-id nil :documentation "Session ID before last directory change.")
@@ -114,14 +115,15 @@ PROPERTIES is a plist of slot names and values."
         (:buffer (setf (magnus-instance-buffer instance) value))
         (:status (setf (magnus-instance-status instance) value))
         (:directory (setf (magnus-instance-directory instance) value))
+        (:provider (setf (magnus-instance-provider instance) value))
         (:session-id (setf (magnus-instance-session-id instance) value))
         (:previous-session-id (setf (magnus-instance-previous-session-id instance) value))
         (:purged-at (setf (magnus-instance-purged-at instance) value)))))
   (run-hooks 'magnus-instances-changed-hook)
   instance)
 
-(defun magnus-instances-create (directory name)
-  "Create a new instance for DIRECTORY with NAME.
+(defun magnus-instances-create (directory name &optional provider)
+  "Create a new instance for DIRECTORY with NAME and optional PROVIDER.
 Returns the new instance (not yet added to registry)."
   (magnus-instance--create
    :id (magnus-instances--generate-id)
@@ -129,6 +131,7 @@ Returns the new instance (not yet added to registry)."
    :directory (directory-file-name (expand-file-name directory))
    :buffer nil
    :created-at (current-time)
+   :provider (or provider 'claude)
    :status 'stopped))
 
 (defun magnus-instances-clear ()
@@ -149,6 +152,7 @@ Returns the new instance (not yet added to registry)."
         :name (magnus-instance-name instance)
         :directory (magnus-instance-directory instance)
         :created-at (magnus-instance-created-at instance)
+        :provider (or (magnus-instance-provider instance) 'claude)
         :session-id (magnus-instance-session-id instance)
         :previous-session-id (magnus-instance-previous-session-id instance)
         :status (magnus-instance-status instance)
@@ -162,6 +166,9 @@ Returns the new instance (not yet added to registry)."
    :directory (plist-get plist :directory)
    :buffer nil
    :created-at (plist-get plist :created-at)
+   ;; State written before provider support has no :provider key and must
+   ;; retain Magnus's original Claude Code behavior.
+   :provider (or (plist-get plist :provider) 'claude)
    :status (or (plist-get plist :status) 'stopped)
    :session-id (plist-get plist :session-id)
    :previous-session-id (plist-get plist :previous-session-id)

--- a/magnus-process.el
+++ b/magnus-process.el
@@ -462,9 +462,9 @@ via `magnus-process-resurrect-purged'."
     (magnus-instances-update instance
                              :status 'purged
                              :buffer nil
-                             :purged-at (float-time))
-    ;; Index expertise tags asynchronously
-    (magnus--agents-index-update instance)))
+                             :purged-at (float-time)))
+  ;; Index expertise tags asynchronously for every provider.
+  (magnus--agents-index-update instance))
 
 (defun magnus-process-resurrect-purged (instance)
   "Resurrect a purged INSTANCE by resuming its provider session.
@@ -484,9 +484,9 @@ nudge the agent to re-read it."
     (if (magnus-provider-external-p instance)
         (magnus-provider-call instance 'resume)
       (magnus-process--spawn-with-session instance session-id))
-    ;; If instructions were outdated, nudge agent to re-read after spawn
-    (when (and instructions-stale
-               (not (magnus-provider-external-p instance)))
+    ;; If instructions were outdated, nudge agent to re-read after spawn.
+    ;; External providers queue this until their resumed TUI is ready.
+    (when instructions-stale
       (run-with-timer
        5 nil
        (lambda ()

--- a/magnus-process.el
+++ b/magnus-process.el
@@ -17,8 +17,12 @@
 (require 'filenotify)
 (require 'vterm)
 (require 'magnus-instances)
+(require 'magnus-provider)
 (require 'magnus-coord)
 (require 'magnus-trace)
+
+(declare-function magnus-instances-create "magnus-instances"
+                  (directory name &optional provider))
 
 (declare-function magnus-status-refresh "magnus-status")
 (declare-function magnus-project-root "magnus")
@@ -33,20 +37,36 @@
 
 ;;; Process creation
 
-(defun magnus-process-create (&optional directory name)
-  "Create a new Claude Code instance.
+(defun magnus-process-create (&optional directory name provider)
+  "Create a new agent instance.
 DIRECTORY is the working directory.  If nil, prompts for one.
-NAME is the instance name.  If nil, auto-generates one."
+NAME is the instance name.  If nil, auto-generates one.
+PROVIDER defaults to `claude', preserving the original vterm behavior."
   (interactive)
   (let* ((dir (or directory
                   (magnus-process--get-directory)))
          (instance-name (or name
                             (funcall magnus-instance-name-generator dir)))
-         (instance (magnus-instances-create dir instance-name)))
+         (instance (magnus-instances-create dir instance-name provider)))
     (magnus-instances-add instance)
     ;; Set up coordination files and register agent
     (magnus-coord-register-agent dir instance)
-    (magnus-process--spawn instance)
+    (if (magnus-provider-external-p instance)
+        (magnus-provider-call instance 'start)
+      (magnus-process--spawn instance))
+    instance))
+
+(defun magnus-process-create-codex (&optional directory name initial-message)
+  "Create an opt-in Codex instance in DIRECTORY with NAME.
+When INITIAL-MESSAGE is non-nil, start a turn after the thread is ready."
+  (interactive)
+  (let* ((dir (or directory (magnus-process--get-directory)))
+         (instance-name (or name
+                            (funcall magnus-instance-name-generator dir)))
+         (instance (magnus-instances-create dir instance-name 'codex)))
+    (magnus-instances-add instance)
+    (magnus-coord-register-agent dir instance)
+    (magnus-provider-call instance 'start initial-message)
     instance))
 
 (defun magnus-process--get-directory ()
@@ -359,8 +379,10 @@ Maps \\`keyboard-quit' to send ESC, since Emacs intercepts the real ESC key."
 
 (defun magnus-process-trace (instance)
   "Open the trace buffer for INSTANCE showing thinking and messages."
-  (require 'magnus-trace)
-  (magnus-trace-open instance))
+  (if (magnus-provider-external-p instance)
+      (magnus-provider-call instance 'switch-to)
+    (require 'magnus-trace)
+    (magnus-trace-open instance)))
 
 (defun magnus-process--session-jsonl-path (directory session-id)
   "Get the JSONL file path for SESSION-ID in DIRECTORY."
@@ -387,53 +409,64 @@ Maps \\`keyboard-quit' to send ESC, since Emacs intercepts the real ESC key."
 ;;; Process control
 
 (defun magnus-process-kill (instance &optional force)
-  "Kill the Claude Code process for INSTANCE.
+  "Kill the agent process for INSTANCE.
 If FORCE is non-nil, forcefully terminate."
-  (when-let ((buffer (magnus-instance-buffer instance)))
-    (when (buffer-live-p buffer)
-      (let ((process (get-buffer-process buffer)))
-        (when (and process (process-live-p process))
-          (if force
-              (kill-process process)
-            ;; Graceful exit: SIGINT for headless, C-c for vterm
-            (if (magnus-process--headless-p instance)
-                (interrupt-process process)
-              (with-current-buffer buffer
-                (vterm-send-key "C-c")))))))
-      ;; Give process time to exit, then kill buffer
-      (run-with-timer
-       1 nil
-       (lambda ()
-         (when (buffer-live-p buffer)
-           (kill-buffer buffer)))))
-  (magnus-instances-update instance :status 'stopped :buffer nil))
+  (if (magnus-provider-external-p instance)
+      (magnus-provider-call instance 'stop force)
+    (when-let ((buffer (magnus-instance-buffer instance)))
+      (when (buffer-live-p buffer)
+        (let ((process (get-buffer-process buffer)))
+          (when (and process (process-live-p process))
+            (if force
+                (kill-process process)
+              ;; Graceful exit: SIGINT for headless, C-c for vterm
+              (if (magnus-process--headless-p instance)
+                  (interrupt-process process)
+                (with-current-buffer buffer
+                  (vterm-send-key "C-c"))))))
+        ;; Give process time to exit, then kill buffer
+        (run-with-timer
+         1 nil
+         (lambda ()
+           (when (buffer-live-p buffer)
+             (kill-buffer buffer))))))
+    (magnus-instances-update instance :status 'stopped :buffer nil)))
 
 (defun magnus-process-archive (instance)
   "Archive INSTANCE: stop its process but keep it in the registry.
 The session ID is preserved so the agent can be resurrected later
 via `magnus-process-resurrect-purged'."
-  (let ((directory (magnus-instance-directory instance)))
-    (magnus-coord-unregister-agent directory instance))
-  ;; Graceful stop (same as kill, but we keep the instance)
-  (when-let ((buffer (magnus-instance-buffer instance)))
-    (when (buffer-live-p buffer)
-      (let ((process (get-buffer-process buffer)))
-        (when (and process (process-live-p process))
-          (if (magnus-process--headless-p instance)
-              (interrupt-process process)
-            (with-current-buffer buffer
-              (vterm-send-key "C-c")))))
-      (run-with-timer
-       1 nil
-       (lambda ()
-         (when (buffer-live-p buffer)
-           (kill-buffer buffer))))))
-  (magnus-instances-update instance
-                           :status 'purged
-                           :buffer nil
-                           :purged-at (float-time))
-  ;; Index expertise tags asynchronously
-  (magnus--agents-index-update instance))
+  (if (magnus-provider-external-p instance)
+      (progn
+        (magnus-coord-unregister-agent
+         (magnus-instance-directory instance) instance)
+        (magnus-provider-call instance 'stop)
+        (magnus-instances-update instance
+                                 :status 'purged
+                                 :buffer nil
+                                 :purged-at (float-time)))
+    (let ((directory (magnus-instance-directory instance)))
+      (magnus-coord-unregister-agent directory instance))
+    ;; Graceful stop (same as kill, but we keep the instance)
+    (when-let ((buffer (magnus-instance-buffer instance)))
+      (when (buffer-live-p buffer)
+        (let ((process (get-buffer-process buffer)))
+          (when (and process (process-live-p process))
+            (if (magnus-process--headless-p instance)
+                (interrupt-process process)
+              (with-current-buffer buffer
+                (vterm-send-key "C-c")))))
+        (run-with-timer
+         1 nil
+         (lambda ()
+           (when (buffer-live-p buffer)
+             (kill-buffer buffer))))))
+    (magnus-instances-update instance
+                             :status 'purged
+                             :buffer nil
+                             :purged-at (float-time))
+    ;; Index expertise tags asynchronously
+    (magnus--agents-index-update instance)))
 
 (defun magnus-process-resurrect-purged (instance)
   "Resurrect a purged INSTANCE by resuming its Claude Code session.
@@ -450,9 +483,12 @@ nudge the agent to re-read it."
                   (magnus-instance-name instance)))
     (magnus-instances-update instance :status 'running :purged-at nil)
     (magnus-coord-register-agent directory instance)
-    (magnus-process--spawn-with-session instance session-id)
+    (if (magnus-provider-external-p instance)
+        (magnus-provider-call instance 'resume)
+      (magnus-process--spawn-with-session instance session-id))
     ;; If instructions were outdated, nudge agent to re-read after spawn
-    (when instructions-stale
+    (when (and instructions-stale
+               (not (magnus-provider-external-p instance)))
       (run-with-timer
        5 nil
        (lambda ()
@@ -467,6 +503,9 @@ nudge the agent to re-read it."
 (defun magnus-process-suspend (instance)
   "Suspend the Claude Code process for INSTANCE.
 Sends SIGTSTP to pause the process.  Use `magnus-process-resume' to continue."
+  (when (magnus-provider-external-p instance)
+    (user-error "Suspend is not supported by the `%s' provider"
+                (magnus-instance-provider instance)))
   (when-let ((buffer (magnus-instance-buffer instance)))
     (when (buffer-live-p buffer)
       (when-let ((process (get-buffer-process buffer)))
@@ -480,6 +519,9 @@ Sends SIGTSTP to pause the process.  Use `magnus-process-resume' to continue."
 (defun magnus-process-resume (instance)
   "Resume a suspended Claude Code process for INSTANCE.
 Sends SIGCONT to continue the process."
+  (when (magnus-provider-external-p instance)
+    (user-error "Process resume is not supported by the `%s' provider"
+                (magnus-instance-provider instance)))
   (when-let ((buffer (magnus-instance-buffer instance)))
     (when (buffer-live-p buffer)
       (when-let ((process (get-buffer-process buffer)))
@@ -496,27 +538,40 @@ Sends SIGCONT to continue the process."
 (defun magnus-process-chdir (instance directory)
   "Change INSTANCE's working directory to DIRECTORY.
 Kills the current process and respawns in the new directory."
-  (let* ((new-dir (expand-file-name directory))
-         (name (magnus-instance-name instance)))
-    ;; Kill old process and buffer immediately (no timers)
-    (when-let ((buffer (magnus-instance-buffer instance)))
-      (when (buffer-live-p buffer)
-        (let ((process (get-buffer-process buffer)))
-          (when (and process (process-live-p process))
-            (kill-process process)))
-        (kill-buffer buffer)))
-    ;; Update directory, clear old session (it belongs to the old project)
-    (magnus-instances-update instance
-                             :directory new-dir
-                             :status 'stopped
-                             :buffer nil
-                             :session-id nil)
-    ;; Spawn fresh in the new directory
-    (run-with-timer
-     1 nil
-     (lambda ()
-       (magnus-process--spawn instance)))
-    (message "Moving %s to %s (fresh start)..." name new-dir)))
+  (if (magnus-provider-external-p instance)
+      (progn
+        (magnus-provider-call instance 'stop t)
+        (magnus-instances-update instance
+                                 :directory (expand-file-name directory)
+                                 :status 'stopped
+                                 :buffer nil
+                                 :session-id nil)
+        (magnus-provider-call instance 'start)
+        (message "Moving %s to %s (fresh %s thread)..."
+                 (magnus-instance-name instance) directory
+                 (magnus-instance-provider instance))
+        instance)
+    (let* ((new-dir (expand-file-name directory))
+           (name (magnus-instance-name instance)))
+      ;; Kill old process and buffer immediately (no timers)
+      (when-let ((buffer (magnus-instance-buffer instance)))
+        (when (buffer-live-p buffer)
+          (let ((process (get-buffer-process buffer)))
+            (when (and process (process-live-p process))
+              (kill-process process)))
+          (kill-buffer buffer)))
+      ;; Update directory, clear old session (it belongs to the old project)
+      (magnus-instances-update instance
+                               :directory new-dir
+                               :status 'stopped
+                               :buffer nil
+                               :session-id nil)
+      ;; Spawn fresh in the new directory
+      (run-with-timer
+       1 nil
+       (lambda ()
+         (magnus-process--spawn instance)))
+      (message "Moving %s to %s (fresh start)..." name new-dir))))
 
 (defun magnus-process--project-hash (directory)
   "Convert DIRECTORY to Claude's project hash format.
@@ -556,42 +611,53 @@ Replaces slashes, spaces, tildes, and underscores with hyphens."
   "Switch to the buffer for INSTANCE.
 If the buffer is nil (e.g. after Emacs restart), resume the session
 if a session ID exists, or spawn a fresh process."
-  (let ((buffer (magnus-instance-buffer instance)))
-    (cond
-     ;; Buffer exists and is live — switch to it
-     ((and buffer (buffer-live-p buffer))
-      (switch-to-buffer buffer))
-     ;; Buffer is dead or nil — need to (re)spawn
-     (t
-      (if-let ((session-id (magnus-instance-session-id instance)))
-          ;; Has a session — resume it
-          (progn
-            (magnus-process--spawn-with-session instance session-id)
-            (switch-to-buffer (magnus-instance-buffer instance)))
-        ;; No session — spawn fresh
-        (magnus-process--spawn instance)
-        (switch-to-buffer (magnus-instance-buffer instance)))))))
+  (if (magnus-provider-external-p instance)
+      (magnus-provider-call instance 'switch-to)
+    (let ((buffer (magnus-instance-buffer instance)))
+      (cond
+       ;; Buffer exists and is live — switch to it
+       ((and buffer (buffer-live-p buffer))
+        (switch-to-buffer buffer))
+       ;; Buffer is dead or nil — need to (re)spawn
+       (t
+        (if-let ((session-id (magnus-instance-session-id instance)))
+            ;; Has a session — resume it
+            (progn
+              (magnus-process--spawn-with-session instance session-id)
+              (switch-to-buffer (magnus-instance-buffer instance)))
+          ;; No session — spawn fresh
+          (magnus-process--spawn instance)
+          (switch-to-buffer (magnus-instance-buffer instance))))))))
 
 (defun magnus-process-running-p (instance)
   "Return non-nil if INSTANCE has a running process."
-  (when-let ((buffer (magnus-instance-buffer instance)))
-    (and (buffer-live-p buffer)
-         (get-buffer-process buffer)
-         (process-live-p (get-buffer-process buffer)))))
+  (if (magnus-provider-external-p instance)
+      (magnus-provider-call instance 'running-p)
+    (when-let ((buffer (magnus-instance-buffer instance)))
+      (and (buffer-live-p buffer)
+           (get-buffer-process buffer)
+           (process-live-p (get-buffer-process buffer))))))
 
 ;;; Reconnection
 
 (defun magnus-process-reconnect (instance)
   "Try to reconnect INSTANCE to an existing buffer/process."
-  (let* ((name (magnus-instance-name instance))
-         (buffer-name (format "*claude:%s*" name))
-         (buffer (get-buffer buffer-name)))
-    (when (and buffer (buffer-live-p buffer))
-      (magnus-instances-update instance
-                               :buffer buffer
-                               :status (if (get-buffer-process buffer)
-                                           'running
-                                         'stopped)))))
+  (if (magnus-provider-external-p instance)
+      (progn
+        ;; App Server stdio connections cannot survive Emacs itself.  Leave the
+        ;; persisted thread ID intact; visiting the instance will resume it.
+        (when (eq (magnus-instance-status instance) 'running)
+          (magnus-instances-update instance :status 'stopped :buffer nil))
+        nil)
+    (let* ((name (magnus-instance-name instance))
+           (buffer-name (format "*claude:%s*" name))
+           (buffer (get-buffer buffer-name)))
+      (when (and buffer (buffer-live-p buffer))
+        (magnus-instances-update instance
+                                 :buffer buffer
+                                 :status (if (get-buffer-process buffer)
+                                             'running
+                                           'stopped))))))
 
 ;;; Headless mode — fire-and-forget agents
 

--- a/magnus-process.el
+++ b/magnus-process.el
@@ -375,10 +375,12 @@ Maps \\`keyboard-quit' to send ESC, since Emacs intercepts the real ESC key."
 
 (defun magnus-process-trace (instance)
   "Open the trace buffer for INSTANCE showing thinking and messages."
-  (if (magnus-provider-external-p instance)
-      (magnus-provider-call instance 'switch-to)
-    (require 'magnus-trace)
-    (magnus-trace-open instance)))
+  (when (and (magnus-provider-external-p instance)
+             (not (magnus-provider-operation-p instance 'trace-file)))
+    (user-error "Provider `%s' does not support thinking traces"
+                (magnus-instance-provider instance)))
+  (require 'magnus-trace)
+  (magnus-trace-open instance))
 
 (defun magnus-process--session-jsonl-path (directory session-id)
   "Get the JSONL file path for SESSION-ID in DIRECTORY."

--- a/magnus-process.el
+++ b/magnus-process.el
@@ -469,7 +469,7 @@ via `magnus-process-resurrect-purged'."
     (magnus--agents-index-update instance)))
 
 (defun magnus-process-resurrect-purged (instance)
-  "Resurrect a purged INSTANCE by resuming its Claude Code session.
+  "Resurrect a purged INSTANCE by resuming its provider session.
 If the instructions file was updated since the agent was archived,
 nudge the agent to re-read it."
   (let* ((session-id (magnus-instance-session-id instance))
@@ -644,8 +644,8 @@ if a session ID exists, or spawn a fresh process."
   "Try to reconnect INSTANCE to an existing buffer/process."
   (if (magnus-provider-external-p instance)
       (progn
-        ;; App Server stdio connections cannot survive Emacs itself.  Leave the
-        ;; persisted thread ID intact; visiting the instance will resume it.
+        ;; The managed daemon may survive Emacs, but its observer connection and
+        ;; vterm cannot.  Preserve the thread ID; visiting resumes a fresh TUI.
         (when (eq (magnus-instance-status instance) 'running)
           (magnus-instances-update instance :status 'stopped :buffer nil))
         nil)

--- a/magnus-process.el
+++ b/magnus-process.el
@@ -37,11 +37,12 @@
 
 ;;; Process creation
 
-(defun magnus-process-create (&optional directory name provider)
+(defun magnus-process-create (&optional directory name provider initial-message)
   "Create a new agent instance.
 DIRECTORY is the working directory.  If nil, prompts for one.
 NAME is the instance name.  If nil, auto-generates one.
-PROVIDER defaults to `claude', preserving the original vterm behavior."
+PROVIDER defaults to `claude', preserving the original vterm behavior.
+INITIAL-MESSAGE is passed to external providers when non-nil."
   (interactive)
   (let* ((dir (or directory
                   (magnus-process--get-directory)))
@@ -52,22 +53,17 @@ PROVIDER defaults to `claude', preserving the original vterm behavior."
     ;; Set up coordination files and register agent
     (magnus-coord-register-agent dir instance)
     (if (magnus-provider-external-p instance)
-        (magnus-provider-call instance 'start)
+        (if initial-message
+            (magnus-provider-call instance 'start initial-message)
+          (magnus-provider-call instance 'start))
       (magnus-process--spawn instance))
     instance))
 
 (defun magnus-process-create-codex (&optional directory name initial-message)
   "Create an opt-in Codex instance in DIRECTORY with NAME.
-When INITIAL-MESSAGE is non-nil, start a turn after the thread is ready."
+When INITIAL-MESSAGE is non-nil, include it in the native TUI's first turn."
   (interactive)
-  (let* ((dir (or directory (magnus-process--get-directory)))
-         (instance-name (or name
-                            (funcall magnus-instance-name-generator dir)))
-         (instance (magnus-instances-create dir instance-name 'codex)))
-    (magnus-instances-add instance)
-    (magnus-coord-register-agent dir instance)
-    (magnus-provider-call instance 'start initial-message)
-    instance))
+  (magnus-process-create directory name 'codex initial-message))
 
 (defun magnus-process--get-directory ()
   "Get directory for new instance, prompting user."
@@ -644,8 +640,8 @@ if a session ID exists, or spawn a fresh process."
   "Try to reconnect INSTANCE to an existing buffer/process."
   (if (magnus-provider-external-p instance)
       (progn
-        ;; The managed daemon may survive Emacs, but its observer connection and
-        ;; vterm cannot.  Preserve the thread ID; visiting resumes a fresh TUI.
+        ;; A provider's terminal cannot survive Emacs.  Preserve its session ID;
+        ;; visiting the instance will resume it in a fresh display buffer.
         (when (eq (magnus-instance-status instance) 'running)
           (magnus-instances-update instance :status 'stopped :buffer nil))
         nil)

--- a/magnus-provider-codex.el
+++ b/magnus-provider-codex.el
@@ -44,6 +44,16 @@ Magnus always supplies a small provider-neutral coordination preamble."
   :type '(choice (const :tag "None" nil) string)
   :group 'magnus)
 
+(defcustom magnus-codex-active-turn-delivery 'queue
+  "How `magnus-codex-send' handles text while a turn is active.
+`queue' preserves Claude/vterm semantics by starting a new turn after the
+current one completes.  `steer' injects the text into the active turn via
+App Server's turn/steer method.  Calls to `magnus-codex-steer' always steer
+regardless of this setting."
+  :type '(choice (const :tag "Queue for the next turn" queue)
+                 (const :tag "Steer the active turn" steer))
+  :group 'magnus)
+
 (defvar magnus-codex-event-hook nil
   "Hook run after a Codex server event.
 Functions receive INSTANCE, METHOD, and PARAMS.")
@@ -58,9 +68,6 @@ Functions receive INSTANCE, REQUEST-ID, METHOD, and PARAMS.  Use
 
 (defvar magnus-codex--active-turns (make-hash-table :test #'equal)
   "Instance ID to active Codex turn ID map.")
-
-(defvar magnus-codex--approvals (make-hash-table :test #'equal)
-  "JSON-RPC request ID to pending approval plist map.")
 
 (defvar-local magnus-codex--instance nil
   "Codex instance represented by the current output buffer.")
@@ -111,6 +118,13 @@ Functions receive INSTANCE, REQUEST-ID, METHOD, and PARAMS.  Use
   (let ((process (gethash (magnus-instance-id instance)
                           magnus-codex--connections)))
     (and (process-live-p process) process)))
+
+(defun magnus-codex--approval-table (process)
+  "Return PROCESS's private pending approval table."
+  (or (process-get process 'magnus-codex-approvals)
+      (let ((table (make-hash-table :test #'equal)))
+        (process-put process 'magnus-codex-approvals table)
+        table)))
 
 (defun magnus-codex--json (object)
   "Serialize OBJECT as compact JSON."
@@ -196,7 +210,7 @@ CALLBACK receives RESULT and ERROR, exactly one of which is non-nil."
         (progn
           (puthash id (list :instance instance :process process
                             :method method :params params)
-                   magnus-codex--approvals)
+                   (magnus-codex--approval-table process))
           (magnus-codex--insert
            instance
            (format "\n[approval pending] %s\n%s\n"
@@ -220,7 +234,14 @@ CALLBACK receives RESULT and ERROR, exactly one of which is non-nil."
   "Return a readable summary of approval PARAMS."
   (string-join
    (delq nil
-         (list (when-let ((command (alist-get 'command params))) command)
+         (list (when-let ((command (alist-get 'command params)))
+                 (cond
+                  ((stringp command) command)
+                  ((listp command)
+                   (string-join (mapcar (lambda (arg) (format "%s" arg))
+                                        command)
+                                " "))
+                  (t (format "%s" command))))
                (when-let ((cwd (alist-get 'cwd params)))
                  (format "cwd: %s" cwd))
                (when-let ((reason (alist-get 'reason params))) reason)))
@@ -230,9 +251,10 @@ CALLBACK receives RESULT and ERROR, exactly one of which is non-nil."
   "Respond to INSTANCE approval REQUEST-ID with DECISION.
 DECISION is normally accept, acceptForSession, decline, or cancel.  A
 permission-profile request instead requires its complete response alist."
-  (let* ((entry (gethash request-id magnus-codex--approvals))
+  (let* ((process (magnus-codex--connection instance))
+         (table (and process (magnus-codex--approval-table process)))
+         (entry (and table (gethash request-id table)))
          (owner (plist-get entry :instance))
-         (process (plist-get entry :process))
          (method (plist-get entry :method))
          (result (if (equal method "item/permissions/requestApproval")
                      decision
@@ -250,7 +272,7 @@ permission-profile request instead requires its complete response alist."
     (magnus-codex--send-object
      process `((jsonrpc . "2.0") (id . ,request-id)
                (result . ,result)))
-    (remhash request-id magnus-codex--approvals)
+    (remhash request-id table)
     (magnus-codex--insert instance
                           (format "[approval answered: %s]\n" decision)
                           'font-lock-comment-face)))
@@ -270,6 +292,7 @@ permission-profile request instead requires its complete response alist."
                              (magnus-codex--format-plan params)
                              'font-lock-comment-face))
       ("turn/started"
+       (process-put process 'magnus-codex-turn-starting nil)
        (let ((turn-id (magnus-codex--turn-id (alist-get 'turn params))))
          (when turn-id
            (puthash (magnus-instance-id instance) turn-id
@@ -278,8 +301,10 @@ permission-profile request instead requires its complete response alist."
                              'font-lock-comment-face))
       ("turn/completed"
        (remhash (magnus-instance-id instance) magnus-codex--active-turns)
+       (process-put process 'magnus-codex-turn-starting nil)
        (magnus-codex--insert instance "\n[turn completed]\n\n"
-                             'font-lock-comment-face))
+                             'font-lock-comment-face)
+       (magnus-codex--start-next-queued-turn process instance))
       ("thread/status/changed"
        (magnus-codex--insert
         instance (format "\n[status: %s]\n"
@@ -318,7 +343,7 @@ permission-profile request instead requires its complete response alist."
     (when-let ((instance (process-get process 'magnus-codex-instance)))
       (remhash (magnus-instance-id instance) magnus-codex--connections)
       (remhash (magnus-instance-id instance) magnus-codex--active-turns)
-      (magnus-codex--clear-approvals instance)
+      (magnus-codex--clear-approvals instance process)
       (unless (eq (magnus-instance-status instance) 'purged)
         (magnus-instances-update instance :status 'stopped))
       (unless (process-get process 'magnus-codex-intentional-stop)
@@ -328,16 +353,13 @@ permission-profile request instead requires its complete response alist."
                  (get-buffer magnus-buffer-name))
         (magnus-status-refresh)))))
 
-(defun magnus-codex--clear-approvals (instance)
+(defun magnus-codex--clear-approvals (instance &optional process)
   "Remove pending approvals owned by INSTANCE."
-  (let (request-ids)
-    (maphash
-     (lambda (request-id entry)
-       (when (eq (plist-get entry :instance) instance)
-         (push request-id request-ids)))
-     magnus-codex--approvals)
-    (dolist (request-id request-ids)
-      (remhash request-id magnus-codex--approvals))))
+  (when-let ((connection
+              (or process
+                  (gethash (magnus-instance-id instance)
+                           magnus-codex--connections))))
+    (clrhash (magnus-codex--approval-table connection))))
 
 (defun magnus-codex--start-process (instance)
   "Start a Codex App Server process for INSTANCE."
@@ -357,8 +379,12 @@ permission-profile request instead requires its complete response alist."
                    :sentinel #'magnus-codex--sentinel)))
     (process-put process 'magnus-codex-instance instance)
     (process-put process 'magnus-codex-pending (make-hash-table :test #'equal))
+    (process-put process 'magnus-codex-approvals
+                 (make-hash-table :test #'equal))
     (process-put process 'magnus-codex-next-id 0)
     (process-put process 'magnus-codex-partial "")
+    (process-put process 'magnus-codex-input-queue nil)
+    (process-put process 'magnus-codex-turn-starting nil)
     (puthash (magnus-instance-id instance) process magnus-codex--connections)
     process))
 
@@ -487,29 +513,65 @@ permission-profile request instead requires its complete response alist."
   "Build App Server user input for TEXT."
   `[((type . "text") (text . ,text))])
 
-(defun magnus-codex-send (instance text)
-  "Send TEXT to Codex INSTANCE, steering when a turn is active."
-  (if-let ((turn-id (gethash (magnus-instance-id instance)
-                             magnus-codex--active-turns)))
-      (magnus-codex-steer instance text turn-id)
-    (let ((process (or (magnus-codex--connection instance)
-                       (user-error "Codex instance is not running")))
-          (thread-id (or (magnus-instance-session-id instance)
-                         (user-error "Codex thread is not ready yet"))))
-      (magnus-codex--insert instance (format "\nYou: %s\n\n" text)
-                            'font-lock-keyword-face)
-      (magnus-codex--request
-       process "turn/start"
-       `((threadId . ,thread-id) (input . ,(magnus-codex--input text)))
-       (lambda (result error)
-         (if error
-             (magnus-codex--insert instance
-                                   (format "[turn/start failed] %s\n" error)
-                                   'error)
-           (let ((turn-id (magnus-codex--turn-id (alist-get 'turn result))))
-             (when turn-id
+(defun magnus-codex--queue-input (process text)
+  "Append TEXT to PROCESS's next-turn input queue."
+  (process-put process 'magnus-codex-input-queue
+               (append (process-get process 'magnus-codex-input-queue)
+                       (list text))))
+
+(defun magnus-codex--start-next-queued-turn (process instance)
+  "Start INSTANCE's next queued turn through PROCESS when idle."
+  (unless (or (gethash (magnus-instance-id instance)
+                       magnus-codex--active-turns)
+              (process-get process 'magnus-codex-turn-starting))
+    (when-let ((queue (process-get process 'magnus-codex-input-queue)))
+      (let ((text (car queue))
+            (thread-id (magnus-instance-session-id instance)))
+        (unless thread-id
+          (user-error "Codex thread is not ready yet"))
+        (process-put process 'magnus-codex-input-queue (cdr queue))
+        (process-put process 'magnus-codex-turn-starting t)
+        (magnus-codex--insert instance (format "\nYou: %s\n\n" text)
+                              'font-lock-keyword-face)
+        (magnus-codex--request
+         process "turn/start"
+         `((threadId . ,thread-id) (input . ,(magnus-codex--input text)))
+         (lambda (result error)
+           (process-put process 'magnus-codex-turn-starting nil)
+           (if error
+               (progn
+                 (process-put
+                  process 'magnus-codex-input-queue
+                  (cons text (process-get process
+                                          'magnus-codex-input-queue)))
+                 (magnus-codex--insert
+                  instance
+                  (format "[turn/start failed; message retained] %s\n" error)
+                  'error))
+             (when-let ((turn-id
+                         (magnus-codex--turn-id (alist-get 'turn result))))
                (puthash (magnus-instance-id instance) turn-id
                         magnus-codex--active-turns)))))))))
+
+(defun magnus-codex-send (instance text)
+  "Send TEXT to Codex INSTANCE according to the active-turn delivery policy.
+By default, text received during an active turn is queued for a new turn so
+coordination nudges match Claude/vterm behavior.  See
+`magnus-codex-active-turn-delivery' and `magnus-codex-steer'."
+  (let* ((process (or (magnus-codex--connection instance)
+                      (user-error "Codex instance is not running")))
+         (_thread-id (or (magnus-instance-session-id instance)
+                         (user-error "Codex thread is not ready yet")))
+         (turn-id (gethash (magnus-instance-id instance)
+                           magnus-codex--active-turns)))
+    (if (and turn-id (eq magnus-codex-active-turn-delivery 'steer))
+        (magnus-codex-steer instance text turn-id)
+      (magnus-codex--queue-input process text)
+      (if (or turn-id (process-get process 'magnus-codex-turn-starting))
+          (magnus-codex--insert instance
+                                "\n[message queued for next turn]\n"
+                                'font-lock-comment-face)
+        (magnus-codex--start-next-queued-turn process instance)))))
 
 (defun magnus-codex-steer (instance text &optional expected-turn-id)
   "Steer active Codex INSTANCE turn with TEXT.
@@ -601,21 +663,24 @@ When FORCE is non-nil, kill it immediately."
   (interactive)
   (unless magnus-codex--instance
     (user-error "This is not a Magnus Codex buffer"))
-  (let (requests)
-    (maphash
-     (lambda (request-id entry)
-       (when (eq (plist-get entry :instance) magnus-codex--instance)
-         (push (cons (format "%s: %s" request-id (plist-get entry :method))
+  (let* ((process (magnus-codex--connection magnus-codex--instance))
+         (table (and process (magnus-codex--approval-table process)))
+         requests)
+    (when table
+      (maphash
+       (lambda (request-id entry)
+         (push (cons (format "%s: %s" request-id
+                             (plist-get entry :method))
                      request-id)
-               requests)))
-     magnus-codex--approvals)
+               requests))
+       table))
     (unless requests
       (user-error "This Codex instance has no pending approvals"))
     (let* ((label (if (= (length requests) 1)
                       (caar requests)
                     (completing-read "Approval: " requests nil t)))
            (request-id (cdr (assoc label requests)))
-           (entry (gethash request-id magnus-codex--approvals)))
+           (entry (gethash request-id table)))
       (when (equal (plist-get entry :method) "item/permissions/requestApproval")
         (user-error "Permission-profile approvals require a custom approval handler"))
       (magnus-codex-respond-approval

--- a/magnus-provider-codex.el
+++ b/magnus-provider-codex.el
@@ -39,7 +39,11 @@
   "Optional function called for each Codex approval request.
 The function receives INSTANCE, REQUEST-ID, METHOD, and PARAMS.  It may call
 `magnus-codex-respond-approval' immediately or later.  When nil, the request
-remains pending and is displayed in the instance buffer."
+remains pending in the hidden observer log; normal interactive approvals are
+displayed and answered by the native TUI.  Fallback observer approvals can be
+answered with `M-x magnus-codex-answer-approval'.  A delayed handler should
+capture `magnus-codex-current-approval-token' during this callback and pass it
+when responding."
   :type '(choice (const :tag "Queue for manual handling" nil)
                  (function :tag "Handler function"))
   :group 'magnus)
@@ -51,9 +55,23 @@ Magnus always supplies a small provider-neutral coordination preamble."
   :group 'magnus)
 
 (defcustom magnus-codex-remote "unix://"
-  "Remote endpoint passed to the Codex TUI.
-The default selects the managed App Server daemon's standard Unix socket."
+  "Unix-socket endpoint shared by the Codex TUI and Magnus observer.
+The default `unix://' selects the managed App Server daemon's standard socket.
+A custom local socket may be written as `unix:///absolute/path'.
+Network WebSocket endpoints are not supported by the observer."
   :type 'string
+  :group 'magnus)
+
+(defcustom magnus-codex-startup-timeout 15
+  "Seconds before an incomplete Codex observer startup is abandoned."
+  :type 'number
+  :group 'magnus)
+
+(defcustom magnus-codex-tui-ready-delay 1.0
+  "Seconds after launching the Codex command before queued input may be sent.
+This protects the login shell command from coordination messages arriving
+during startup."
+  :type 'number
   :group 'magnus)
 
 (defvar magnus-codex-event-hook nil
@@ -65,6 +83,11 @@ Functions receive INSTANCE, METHOD, and PARAMS.")
 Functions receive INSTANCE, REQUEST-ID, METHOD, and PARAMS.  Use
 `magnus-codex-respond-approval' to answer the request.")
 
+(defvar magnus-codex-current-approval-token nil
+  "Generation token dynamically bound while approval callbacks run.
+Delayed approval handlers should retain this value and pass it to
+`magnus-codex-respond-approval'.")
+
 (defvar magnus-codex--connections (make-hash-table :test #'equal)
   "Instance ID to App Server observer proxy map.")
 
@@ -74,11 +97,20 @@ Functions receive INSTANCE, REQUEST-ID, METHOD, and PARAMS.  Use
 (defvar magnus-codex--show-on-ready (make-hash-table :test #'equal)
   "Instance IDs whose TUI should be displayed after asynchronous startup.")
 
-(defvar magnus-codex--new-thread-owner nil
-  "Instance ID currently waiting for its TUI-created thread ID.")
+(defvar magnus-codex--retired-approval-ids (make-hash-table :test #'equal)
+  "Instance/request IDs retired while a delayed answer may still exist.")
 
-(defvar magnus-codex--new-thread-queue nil
-  "FIFO of (PROCESS INSTANCE INITIAL-MESSAGE) waiting to create TUI threads.")
+(defvar magnus-codex--input-queues (make-hash-table :test #'equal)
+  "Instance ID to FIFO of text waiting for serialized TUI submission.")
+
+(defvar magnus-codex--input-busy (make-hash-table :test #'equal)
+  "Instance IDs with an automated TUI submission in flight.")
+
+(defvar magnus-codex--input-retry (make-hash-table :test #'equal)
+  "Instance IDs waiting for the user to leave their TUI buffer.")
+
+(defvar magnus-codex--tui-ready (make-hash-table :test #'equal)
+  "Instance IDs whose TUI launch command has been submitted.")
 
 (defvar-local magnus-codex--instance nil
   "Magnus instance represented by the current Codex TUI buffer.")
@@ -378,22 +410,42 @@ CALLBACK receives RESULT and ERROR, exactly one of which is non-nil."
 
 (defun magnus-codex--handle-server-request (process id method params)
   "Handle server request ID METHOD PARAMS from PROCESS."
-  (let ((instance (process-get process 'magnus-codex-instance)))
-    (if (magnus-codex--approval-method-p method)
+  (let* ((instance (process-get process 'magnus-codex-instance))
+         (thread-id (alist-get 'threadId params))
+         (owned-thread (magnus-instance-session-id instance)))
+    (if (and (magnus-codex--approval-method-p method)
+             owned-thread
+             (equal thread-id owned-thread))
         (progn
-          (puthash id (list :instance instance :process process
-                            :method method :params params)
+          (let* ((key (cons (magnus-instance-id instance) id))
+                 (token (secure-hash
+                         'sha256
+                         (format "%s:%s:%s:%s" (car key) id
+                                 (float-time) (random)))))
+            (puthash id (list :instance instance :process process
+                              :method method :params params :token token
+                              :requires-token
+                              (gethash key magnus-codex--retired-approval-ids))
                    (magnus-codex--approval-table process))
+            (remhash key magnus-codex--retired-approval-ids))
           (magnus-codex--insert
            instance
            (format "\n[approval pending] %s\n%s\n"
                    method (magnus-codex--approval-summary params))
            'warning)
-          (run-hook-with-args 'magnus-codex-approval-request-hook
-                              instance id method params)
-          (when magnus-codex-approval-handler
-            (run-at-time 0 nil magnus-codex-approval-handler
-                         instance id method params)))
+          (let ((token (plist-get
+                        (gethash id (magnus-codex--approval-table process))
+                        :token)))
+            (let ((magnus-codex-current-approval-token token))
+              (run-hook-with-args 'magnus-codex-approval-request-hook
+                                  instance id method params))
+            (when magnus-codex-approval-handler
+              (let ((handler magnus-codex-approval-handler))
+                (run-at-time
+                 0 nil
+                 (lambda ()
+                   (let ((magnus-codex-current-approval-token token))
+                     (funcall handler instance id method params))))))))
       (magnus-codex--insert instance
                             (format "\n[unsupported server request] %s\n"
                                     method)
@@ -401,7 +453,7 @@ CALLBACK receives RESULT and ERROR, exactly one of which is non-nil."
       (magnus-codex--send-object
        process `((jsonrpc . "2.0") (id . ,id)
                  (error . ((code . -32601)
-                           (message . "Unsupported server request"))))))))
+                           (message . "Unsupported or misrouted server request"))))))))
 
 (defun magnus-codex--approval-summary (params)
   "Return a readable summary of approval PARAMS."
@@ -420,10 +472,30 @@ CALLBACK receives RESULT and ERROR, exactly one of which is non-nil."
                (when-let ((reason (alist-get 'reason params))) reason)))
    "\n"))
 
-(defun magnus-codex-respond-approval (instance request-id decision)
+(defun magnus-codex-approval-token (instance request-id)
+  "Return the generation token for INSTANCE's pending REQUEST-ID.
+Custom handlers that retain an approval for later should retain this token and
+pass it back to `magnus-codex-respond-approval'."
+  (when-let* ((process (magnus-codex--connection instance))
+              (entry (gethash request-id
+                              (magnus-codex--approval-table process))))
+    (plist-get entry :token)))
+
+(defun magnus-codex--command-approval-decision-p (decision)
+  "Return non-nil when DECISION has a current command approval shape."
+  (or (member decision '("accept" "acceptForSession" "decline" "cancel"))
+      (and (listp decision)
+           (or (alist-get 'acceptWithExecpolicyAmendment decision)
+               (alist-get 'applyNetworkPolicyAmendment decision)))))
+
+(defun magnus-codex-respond-approval (instance request-id decision
+                                               &optional generation-token)
   "Respond to INSTANCE approval REQUEST-ID with DECISION.
-DECISION is normally accept, acceptForSession, decline, or cancel.  A
-permission-profile request instead requires its complete response alist."
+DECISION is normally accept, acceptForSession, decline, cancel, or one of the
+structured policy-amendment decisions advertised by App Server.  A permission-
+profile request instead requires its complete response alist.
+Delayed handlers should also supply GENERATION-TOKEN, obtained from
+`magnus-codex-approval-token', so a reconnect cannot redirect their answer."
   (let* ((process (magnus-codex--connection instance))
          (table (and process (magnus-codex--approval-table process)))
          (entry (and table (gethash request-id table)))
@@ -434,13 +506,20 @@ permission-profile request instead requires its complete response alist."
                    `((decision . ,decision)))))
     (unless (and entry (eq owner instance))
       (user-error "No pending Codex approval %s for this instance" request-id))
+    (when (and (plist-get entry :requires-token)
+               (not (equal generation-token (plist-get entry :token))))
+      (user-error
+       "Approval %s was reused after reconnect; a generation token is required"
+       request-id))
+    (when (and generation-token
+               (not (equal generation-token (plist-get entry :token))))
+      (user-error "Stale Codex approval %s for this connection" request-id))
     (when (and (equal method "item/permissions/requestApproval")
                (not (and (listp decision)
                          (alist-get 'permissions decision))))
       (user-error "Permission approval requires a response alist with permissions"))
     (when (and (not (equal method "item/permissions/requestApproval"))
-               (not (member decision
-                            '("accept" "acceptForSession" "decline" "cancel"))))
+               (not (magnus-codex--command-approval-decision-p decision)))
       (user-error "Unsupported Codex approval decision: %s" decision))
     (magnus-codex--send-object
      process `((jsonrpc . "2.0") (id . ,request-id)
@@ -461,17 +540,11 @@ permission-profile request instead requires its complete response alist."
       ("item/agentMessage/delta"
        (magnus-codex--insert instance (or (alist-get 'delta params) "")))
       ("thread/started"
-       (when (and (process-get process 'magnus-codex-awaiting-tui-thread)
-                  (equal magnus-codex--new-thread-owner
-                         (magnus-instance-id instance)))
-         (when-let ((thread-id
-                     (alist-get 'id (alist-get 'thread params))))
-           (process-put process 'magnus-codex-awaiting-tui-thread nil)
-           (magnus-instances-update instance :session-id thread-id)
+       (when-let ((thread-id (alist-get 'id (alist-get 'thread params))))
+         (when (equal thread-id (magnus-instance-session-id instance))
            (magnus-codex--insert
-            instance (format "[TUI thread started: %s]\n" thread-id)
-            'font-lock-comment-face)
-           (magnus-codex--release-new-thread-owner instance))))
+            instance (format "[observer subscribed to thread: %s]\n" thread-id)
+            'font-lock-comment-face))))
       ("turn/plan/updated"
        (magnus-codex--insert instance
                              (magnus-codex--format-plan params)
@@ -525,22 +598,22 @@ permission-profile request instead requires its complete response alist."
   "Handle observer PROCESS termination EVENT."
   (unless (process-live-p process)
     (when-let ((instance (process-get process 'magnus-codex-instance)))
-      (when (process-get process 'magnus-codex-awaiting-tui-thread)
-        (process-put process 'magnus-codex-awaiting-tui-thread nil)
-        (when-let ((terminal (magnus-codex--tui-process instance)))
-          (set-process-query-on-exit-flag terminal nil)
-          (kill-process terminal))
-        (magnus-codex--release-new-thread-owner instance))
-      (when (eq process (gethash (magnus-instance-id instance)
-                                 magnus-codex--connections))
-        (remhash (magnus-instance-id instance) magnus-codex--connections))
-      (remhash (magnus-instance-id instance) magnus-codex--active-turns)
-      (magnus-codex--clear-approvals instance process)
-      ;; Once the TUI owns the thread, observer failure must not terminate or
-      ;; misreport the interactive session.  Before that handoff it is fatal.
-      (unless (or (magnus-codex--tui-process instance)
-                  (eq (magnus-instance-status instance) 'purged))
-        (magnus-instances-update instance :status 'stopped))
+      (magnus-codex--cancel-startup-timeout process)
+      (let ((current
+             (eq process (gethash (magnus-instance-id instance)
+                                  magnus-codex--connections))))
+        (when current
+          (remhash (magnus-instance-id instance) magnus-codex--connections)
+          (remhash (magnus-instance-id instance) magnus-codex--active-turns))
+        ;; Approval retirement is process-local and remains necessary even for
+        ;; a stale sentinel.  Instance-global lifecycle state is current-only.
+        (magnus-codex--clear-approvals instance process)
+        ;; Once the TUI owns the thread, observer failure must not terminate or
+        ;; misreport the interactive session.  Before that handoff it is fatal.
+        (when (and current
+                   (not (magnus-codex--tui-process instance))
+                   (not (eq (magnus-instance-status instance) 'purged)))
+          (magnus-instances-update instance :status 'stopped)))
       (unless (process-get process 'magnus-codex-intentional-stop)
         (magnus-codex--insert instance (format "\n[observer %s]" event)
                               'font-lock-comment-face))
@@ -549,40 +622,116 @@ permission-profile request instead requires its complete response alist."
         (magnus-status-refresh)))))
 
 (defun magnus-codex--clear-approvals (instance &optional process)
-  "Remove pending approvals owned by INSTANCE."
+  "Retire and remove pending approvals owned by INSTANCE."
   (when-let ((connection
               (or process
                   (gethash (magnus-instance-id instance)
                            magnus-codex--connections))))
-    (clrhash (magnus-codex--approval-table connection))))
+    (let ((table (magnus-codex--approval-table connection))
+          (instance-id (magnus-instance-id instance)))
+      (maphash
+       (lambda (request-id _entry)
+         (puthash (cons instance-id request-id) t
+                  magnus-codex--retired-approval-ids))
+       table)
+      (clrhash table))))
+
+(defun magnus-codex--default-socket ()
+  "Return the managed App Server daemon's standard Unix socket path."
+  (expand-file-name
+   "app-server-control/app-server-control.sock"
+   (or (getenv "CODEX_HOME") (expand-file-name ".codex" "~"))))
+
+(defun magnus-codex--remote-socket ()
+  "Return the Unix socket selected by `magnus-codex-remote'."
+  (cond
+   ((equal magnus-codex-remote "unix://")
+    (magnus-codex--default-socket))
+   ((string-match "\\`unix://\\(.+\\)\\'" magnus-codex-remote)
+    (let ((path (match-string 1 magnus-codex-remote)))
+      (unless (file-name-absolute-p path)
+        (user-error "Codex custom Unix socket must be absolute: %s" path))
+      path))
+   (t
+    (user-error "Magnus observer supports unix:// endpoints, not %s"
+                magnus-codex-remote))))
+
+(defun magnus-codex--socket-live-p (socket)
+  "Return non-nil when a local listener accepts connections at SOCKET."
+  (condition-case nil
+      (let ((probe (make-network-process
+                    :name "magnus-codex-socket-probe"
+                    :family 'local :service socket
+                    :coding 'binary :noquery t)))
+        (delete-process probe)
+        t)
+    (file-error nil)))
 
 (defun magnus-codex--ensure-daemon ()
-  "Ensure the managed local Codex App Server daemon is running."
+  "Ensure the selected local App Server endpoint is healthy.
+Return its Unix socket path."
   (unless (executable-find magnus-codex-executable)
     (user-error "Cannot find Codex executable: %s" magnus-codex-executable))
-  (let ((socket (expand-file-name
-                 "app-server-control/app-server-control.sock"
-                 (or (getenv "CODEX_HOME")
-                     (expand-file-name ".codex" "~")))))
-    ;; `daemon start' can wait on its management lock when invoked from a GUI
-    ;; Emacs even though the healthy daemon socket already exists.
-    (unless (file-exists-p socket)
-      (with-temp-buffer
-        (let ((status (process-file magnus-codex-executable nil t nil
-                                    "app-server" "daemon" "start")))
-          (unless (and (integerp status) (zerop status))
-            (user-error "Could not start Codex App Server daemon: %s"
-                        (string-trim (buffer-string)))))))))
+  (let ((socket (magnus-codex--remote-socket)))
+    (if (equal magnus-codex-remote "unix://")
+        (unless (magnus-codex--socket-live-p socket)
+          (with-temp-buffer
+            (let ((status (process-file magnus-codex-executable nil t nil
+                                        "app-server" "daemon" "start")))
+              (unless (and (integerp status) (zerop status)
+                           (magnus-codex--socket-live-p socket))
+                (user-error "Could not start Codex App Server daemon: %s"
+                            (string-trim (buffer-string)))))))
+      (unless (magnus-codex--socket-live-p socket)
+        (user-error "No Codex App Server is listening at %s" socket)))
+    socket))
 
-(defun magnus-codex--start-process (instance)
+(defun magnus-codex--cancel-startup-timeout (process)
+  "Cancel PROCESS's startup deadline, when present."
+  (when-let ((timer (process-get process 'magnus-codex-startup-timer)))
+    (cancel-timer timer)
+    (process-put process 'magnus-codex-startup-timer nil)))
+
+(defun magnus-codex--arm-startup-timeout (process instance)
+  "Fail PROCESS startup after the configured deadline for INSTANCE."
+  (process-put
+   process 'magnus-codex-startup-timer
+   (run-at-time
+    magnus-codex-startup-timeout nil
+    (lambda ()
+      (when (and (process-live-p process)
+                 (eq process (magnus-codex--connection instance))
+                 (not (magnus-codex--tui-process instance)))
+        (magnus-codex--insert
+         instance
+         (format "[startup timed out after %.1f seconds]\n"
+                 magnus-codex-startup-timeout)
+         'error)
+        (process-put process 'magnus-codex-intentional-stop t)
+        (delete-process process)
+        (unless (eq (magnus-instance-status instance) 'purged)
+          (magnus-instances-update instance :status 'stopped :buffer nil)))))))
+
+(defun magnus-codex--register-connection (instance process)
+  "Install PROCESS as INSTANCE's observer after retiring an older generation."
+  (let* ((id (magnus-instance-id instance))
+         (old (gethash id magnus-codex--connections)))
+    (when (and old (not (eq old process)))
+      (magnus-codex--clear-approvals instance old))
+    (puthash id process magnus-codex--connections)))
+
+(defun magnus-codex--start-process (instance socket)
   "Start INSTANCE's semantic observer proxy to the managed daemon."
   (let* ((name (format "magnus-codex-%s" (magnus-instance-id instance)))
          (stderr (get-buffer-create (format " *%s-stderr*" name)))
          (default-directory (magnus-instance-directory instance))
+         (command (append
+                   (list magnus-codex-executable "app-server" "proxy")
+                   (unless (equal socket (magnus-codex--default-socket))
+                     (list "--sock" socket))))
          (process (make-process
                    :name name
-                   :command (list magnus-codex-executable
-                                  "app-server" "proxy")
+                   :command command
                    :connection-type 'pipe
                    :coding 'binary
                    :noquery t
@@ -600,19 +749,20 @@ permission-profile request instead requires its complete response alist."
     (process-put process 'magnus-codex-frame-buffer
                  (magnus-codex--byte-string))
     (process-put process 'magnus-codex-websocket-ready nil)
-    (process-put process 'magnus-codex-input-queue nil)
     (process-put process 'magnus-codex-turn-starting nil)
-    (puthash (magnus-instance-id instance) process magnus-codex--connections)
+    (magnus-codex--register-connection instance process)
+    (magnus-codex--arm-startup-timeout process instance)
     process))
 
 (defun magnus-codex-start (instance &optional initial-message)
   "Start or resume Codex INSTANCE in a TUI.
 INITIAL-MESSAGE, when non-nil, is submitted by the TUI as its first prompt."
-  (when (magnus-codex--connection instance)
+  (when (or (magnus-codex--connection instance)
+            (magnus-codex--tui-process instance))
     (user-error "Codex instance `%s' is already running"
                 (magnus-instance-name instance)))
-  (magnus-codex--ensure-daemon)
-  (let ((process (magnus-codex--start-process instance)))
+  (let* ((socket (magnus-codex--ensure-daemon))
+         (process (magnus-codex--start-process instance socket)))
     (process-put process 'magnus-codex-on-open
                  (lambda ()
                    (magnus-codex--initialize
@@ -636,56 +786,66 @@ INITIAL-MESSAGE, when non-nil, is submitted by the TUI as its first prompt."
            (delete-process process))
        (magnus-codex--notify process "initialized")
        (if (magnus-instance-session-id instance)
-           (progn
-             (magnus-codex--insert
-              instance
-              (format "[handing saved thread to TUI: %s]\n"
-                      (magnus-instance-session-id instance))
-              'font-lock-comment-face)
-             (magnus-codex--spawn-tui instance initial-message))
-         (magnus-codex--start-new-thread
+           (magnus-codex--resume-observer-thread
+            process instance initial-message)
+         (magnus-codex--create-observer-thread
           process instance initial-message))))))
 
-(defun magnus-codex--start-new-thread (process instance initial-message)
-  "Launch a new TUI-owned thread, serializing its identity handoff."
-  (if magnus-codex--new-thread-owner
-      (setq magnus-codex--new-thread-queue
-            (append magnus-codex--new-thread-queue
-                    (list (list process instance initial-message))))
-    (setq magnus-codex--new-thread-owner (magnus-instance-id instance))
-    (process-put process 'magnus-codex-awaiting-tui-thread t)
-    (magnus-codex--spawn-tui
-     instance (magnus-codex--onboarding-prompt instance initial-message))))
+(defun magnus-codex--startup-failed (process instance phase error)
+  "Record startup ERROR during PHASE and stop observer PROCESS for INSTANCE."
+  (magnus-codex--insert instance (format "[%s failed] %s\n" phase error) 'error)
+  (when (process-live-p process)
+    (delete-process process)))
+
+(defun magnus-codex--create-observer-thread (process instance initial-message)
+  "Create and subscribe PROCESS to a new thread before opening INSTANCE's TUI."
+  (magnus-codex--request
+   process "thread/start"
+   `((cwd . ,(magnus-instance-directory instance))
+     (developerInstructions . ,(magnus-codex--instructions instance)))
+   (lambda (result error)
+     (cond
+      (error
+       (magnus-codex--startup-failed process instance "thread/start" error))
+      ((not (eq process (magnus-codex--connection instance))) nil)
+      (t
+       (let ((thread-id (alist-get 'id (alist-get 'thread result))))
+         (if (not thread-id)
+             (magnus-codex--startup-failed
+              process instance "thread/start" "response contained no thread ID")
+           (magnus-instances-update instance :session-id thread-id)
+           (magnus-codex--insert
+            instance (format "[observer created thread: %s]\n" thread-id)
+            'font-lock-comment-face)
+           (magnus-codex--spawn-tui
+            instance (magnus-codex--onboarding-prompt
+                      instance initial-message)))))))))
+
+(defun magnus-codex--resume-observer-thread (process instance initial-message)
+  "Subscribe PROCESS to INSTANCE's saved thread before opening its TUI."
+  (let ((thread-id (magnus-instance-session-id instance)))
+    (magnus-codex--request
+     process "thread/resume" `((threadId . ,thread-id))
+     (lambda (_result error)
+       (cond
+        (error
+         (magnus-codex--startup-failed process instance "thread/resume" error))
+        ((not (eq process (magnus-codex--connection instance))) nil)
+        (t
+         (magnus-codex--insert
+          instance (format "[observer resumed thread: %s]\n" thread-id)
+          'font-lock-comment-face)
+         (magnus-codex--spawn-tui instance initial-message)))))))
 
 (defun magnus-codex--onboarding-prompt (instance &optional initial-message)
   "Return durable first-turn onboarding for INSTANCE and INITIAL-MESSAGE.
-Remote TUI-created threads do not reliably honor CLI developer-instruction
-overrides, so the den contract is made visible and persistent in history."
+The den contract is also made visible and persistent in user history."
   (concat
    (magnus-codex--instructions instance)
    (if initial-message
        (concat "\n\nInitial task from the user:\n" initial-message)
      (concat "\n\nNo separate task was supplied. Complete your orientation, "
              "report that you are ready, and then wait for the user."))))
-
-(defun magnus-codex--release-new-thread-owner (instance)
-  "Release INSTANCE's new-thread handoff lock and start the next TUI."
-  (when (equal magnus-codex--new-thread-owner
-               (magnus-instance-id instance))
-    (setq magnus-codex--new-thread-owner nil)
-    (magnus-codex--start-next-new-thread)))
-
-(defun magnus-codex--start-next-new-thread ()
-  "Start the next valid queued new Codex TUI, if any."
-  (let (entry)
-    (while (and magnus-codex--new-thread-queue (not entry))
-      (let ((candidate (pop magnus-codex--new-thread-queue)))
-        (when (and (process-live-p (car candidate))
-                   (not (eq (magnus-instance-status (cadr candidate))
-                            'purged)))
-          (setq entry candidate))))
-    (when entry
-      (apply #'magnus-codex--start-new-thread entry))))
 
 (defun magnus-codex--tui-command (instance &optional initial-message)
   "Return the shell command used to run INSTANCE's new or resumed TUI.
@@ -707,6 +867,9 @@ INITIAL-MESSAGE becomes the optional initial prompt."
          (default-directory (magnus-instance-directory instance))
          (buffer (magnus-process--create-vterm-buffer buffer-name))
          (command (magnus-codex--tui-command instance initial-message)))
+    (when-let ((observer (magnus-codex--connection instance)))
+      (magnus-codex--cancel-startup-timeout observer))
+    (remhash (magnus-instance-id instance) magnus-codex--tui-ready)
     (with-current-buffer buffer
       (setq-local magnus-codex--instance instance))
     ;; A freshly created vterm may still be initializing its login shell.  Give
@@ -722,7 +885,16 @@ INITIAL-MESSAGE becomes the optional initial prompt."
      (lambda ()
        (when (buffer-live-p buffer)
          (with-current-buffer buffer
-           (vterm-send-return)))))
+           (vterm-send-return))
+         (run-with-timer
+          magnus-codex-tui-ready-delay nil
+          (lambda ()
+            (when (and (buffer-live-p buffer)
+                       (eq buffer (magnus-instance-buffer instance))
+                       (magnus-codex--tui-process instance))
+              (puthash (magnus-instance-id instance) t
+                       magnus-codex--tui-ready)
+              (magnus-codex--drain-input-queue instance)))))))
     (magnus-instances-update instance :buffer buffer :status 'running)
     (magnus-codex--setup-tui-sentinel instance buffer)
     (when (gethash (magnus-instance-id instance) magnus-codex--show-on-ready)
@@ -753,10 +925,14 @@ INITIAL-MESSAGE becomes the optional initial prompt."
                     (eq terminal
                         (get-buffer-process
                          (magnus-instance-buffer instance))))
-           (when (and (null (magnus-instance-session-id instance))
-                      (equal magnus-codex--new-thread-owner
-                             (magnus-instance-id instance)))
-             (magnus-codex--release-new-thread-owner instance))
+           (remhash (magnus-instance-id instance) magnus-codex--tui-ready)
+           (remhash (magnus-instance-id instance) magnus-codex--input-busy)
+           (when-let ((timer
+                       (gethash (magnus-instance-id instance)
+                                magnus-codex--input-retry)))
+             (cancel-timer timer))
+           (remhash (magnus-instance-id instance) magnus-codex--input-retry)
+           (remhash (magnus-instance-id instance) magnus-codex--input-queues)
            (unless (eq (magnus-instance-status instance) 'purged)
              (magnus-instances-update instance :status 'stopped))
            (when (and (boundp 'magnus-buffer-name)
@@ -836,56 +1012,164 @@ INITIAL-MESSAGE becomes the optional initial prompt."
 
 (defun magnus-codex-send (instance text)
   "Submit TEXT through INSTANCE's Codex TUI.
-The semantic observer never starts or steers turns; this keeps the TUI as the
-only interactive writer and lets Codex apply its native input semantics."
+Messages are serialized so concurrent coordination deliveries cannot merge.
+The semantic observer never starts or steers turns; the TUI remains the only
+interactive writer and Codex applies its native input semantics."
   (let ((buffer (magnus-instance-buffer instance)))
     (unless (and (buffer-live-p buffer) (magnus-codex--tui-process instance))
       (user-error "Codex instance `%s' is not running"
                   (magnus-instance-name instance)))
-    (with-current-buffer buffer
-      (vterm-send-string text))
-    (run-with-timer
-     0.1 nil
-     (lambda ()
-       (when (and (buffer-live-p buffer)
-                  (process-live-p (get-buffer-process buffer)))
-         (with-current-buffer buffer
-           (vterm-send-return)))))))
+    (let* ((id (magnus-instance-id instance))
+           (queue (gethash id magnus-codex--input-queues)))
+      (puthash id (append queue (list text)) magnus-codex--input-queues)
+      (magnus-codex--drain-input-queue instance))))
+
+(defun magnus-codex--drain-input-queue (instance)
+  "Submit the next queued TUI message for INSTANCE, if it is safe to do so."
+  (let* ((id (magnus-instance-id instance))
+         (buffer (magnus-instance-buffer instance))
+         (queue (gethash id magnus-codex--input-queues)))
+    (when (and queue
+               (gethash id magnus-codex--tui-ready)
+               (not (gethash id magnus-codex--input-busy))
+               (buffer-live-p buffer)
+               (magnus-codex--tui-process instance))
+      (if (eq buffer (window-buffer (selected-window)))
+          ;; Never append to or submit a composer while the user is actively in
+          ;; that TUI.  Retry once they move away.
+          (unless (gethash id magnus-codex--input-retry)
+            (puthash
+             id
+             (run-with-timer
+              1.0 nil
+              (lambda ()
+                (remhash id magnus-codex--input-retry)
+                (magnus-codex--drain-input-queue instance)))
+             magnus-codex--input-retry))
+        (let ((text (car queue)))
+          (puthash id (cdr queue) magnus-codex--input-queues)
+          (puthash id t magnus-codex--input-busy)
+          ;; Bracketed paste and Return are emitted in one Emacs event, so user
+          ;; keystrokes cannot interleave two Magnus deliveries.
+          (with-current-buffer buffer
+            (vterm-send-string text t)
+            (vterm-send-return))
+          (run-with-timer
+           0.1 nil
+           (lambda ()
+             (remhash id magnus-codex--input-busy)
+             (magnus-codex--drain-input-queue instance))))))))
 
 (defun magnus-codex-steer (instance text &optional _expected-turn-id)
   "Submit TEXT through INSTANCE's TUI using Codex's native active-turn UI."
   (magnus-codex-send instance text))
 
 (defun magnus-codex-interrupt (instance)
-  "Interrupt the active turn through Codex INSTANCE's TUI."
-  (let ((buffer (magnus-instance-buffer instance)))
+  "Interrupt Codex INSTANCE semantically, falling back to its TUI."
+  (let* ((buffer (magnus-instance-buffer instance))
+         (process (magnus-codex--connection instance))
+         (thread-id (magnus-instance-session-id instance))
+         (turn-id (gethash (magnus-instance-id instance)
+                           magnus-codex--active-turns)))
     (unless (and (buffer-live-p buffer) (magnus-codex--tui-process instance))
       (user-error "Codex instance `%s' is not running"
                   (magnus-instance-name instance)))
-    (with-current-buffer buffer
-      (vterm-send-key "C-c"))))
+    (if (and process thread-id turn-id)
+        (magnus-codex--request
+         process "turn/interrupt"
+         `((threadId . ,thread-id) (turnId . ,turn-id))
+         (lambda (_result error)
+           (when error
+             (magnus-codex--insert
+              instance (format "[turn/interrupt failed] %s\n" error) 'error))))
+      (with-current-buffer buffer
+        (vterm-send-key "C-c")))))
+
+(defun magnus-codex--finalize-stop (instance observer buffer force)
+  "Close INSTANCE's captured OBSERVER and BUFFER after semantic shutdown.
+FORCE selects immediate process killing."
+  (when observer
+    ;; Retire request IDs before deleting or replacing this connection; its
+    ;; sentinel may run after a new observer has already received reused IDs.
+    (magnus-codex--clear-approvals instance observer)
+    (process-put observer 'magnus-codex-intentional-stop t)
+    (when (process-live-p observer)
+      (if force (kill-process observer) (delete-process observer))))
+  (when (buffer-live-p buffer)
+    (when-let ((terminal (get-buffer-process buffer)))
+      (set-process-query-on-exit-flag terminal nil)
+      (when (process-live-p terminal)
+        (if force (kill-process terminal) (delete-process terminal))))
+    (kill-buffer buffer))
+  (let* ((id (magnus-instance-id instance))
+         (current-observer (gethash id magnus-codex--connections))
+         (semantic-current
+          (or (null current-observer) (eq observer current-observer)))
+         (current-buffer (magnus-instance-buffer instance))
+         (ui-current (or (eq buffer current-buffer) (null current-buffer))))
+    (when semantic-current
+      (remhash id magnus-codex--connections))
+    (when semantic-current
+      (remhash id magnus-codex--active-turns))
+    (when ui-current
+      (remhash id magnus-codex--show-on-ready)
+      (remhash id magnus-codex--tui-ready)
+      (remhash id magnus-codex--input-busy)
+      (when-let ((timer (gethash id magnus-codex--input-retry)))
+        (cancel-timer timer))
+      (remhash id magnus-codex--input-retry)
+      (remhash id magnus-codex--input-queues))
+    (when (and semantic-current ui-current
+               (not (eq (magnus-instance-status instance) 'purged)))
+      (magnus-instances-update instance :status 'stopped :buffer nil))))
 
 (defun magnus-codex-stop (instance &optional force)
   "Stop Codex INSTANCE's TUI and observer, never the shared daemon.
-When FORCE is non-nil, kill subprocesses immediately."
-  (let ((buffer (magnus-instance-buffer instance)))
-    (when-let ((observer (magnus-codex--connection instance)))
-      (process-put observer 'magnus-codex-intentional-stop t)
-      (if force (kill-process observer) (delete-process observer)))
-    (when (buffer-live-p buffer)
-      (when-let ((terminal (get-buffer-process buffer)))
-        (set-process-query-on-exit-flag terminal nil)
-        (when (process-live-p terminal)
-          (if force (kill-process terminal) (delete-process terminal))))
-      (kill-buffer buffer)))
-  (remhash (magnus-instance-id instance) magnus-codex--connections)
-  (remhash (magnus-instance-id instance) magnus-codex--active-turns)
-  (remhash (magnus-instance-id instance) magnus-codex--show-on-ready)
-  (setq magnus-codex--new-thread-queue
-        (cl-remove-if (lambda (entry) (eq (cadr entry) instance))
-                      magnus-codex--new-thread-queue))
-  (magnus-codex--release-new-thread-owner instance)
-  (magnus-instances-update instance :status 'stopped :buffer nil))
+When a turn is active, request `turn/interrupt' before closing the clients.
+FORCE shortens the bounded grace period and kills local subprocesses."
+  (let* ((observer (magnus-codex--connection instance))
+         (buffer (magnus-instance-buffer instance))
+         (thread-id (magnus-instance-session-id instance))
+         (turn-id (gethash (magnus-instance-id instance)
+                           magnus-codex--active-turns))
+         (finished nil))
+    (unless (eq (magnus-instance-status instance) 'purged)
+      (magnus-instances-update instance :status 'stopped))
+    (cl-labels
+        ((finish ()
+           (unless finished
+             (setq finished t)
+             (magnus-codex--finalize-stop
+              instance observer buffer force)))
+         (tui-fallback ()
+           (if (and (buffer-live-p buffer)
+                    (magnus-codex--tui-process instance))
+               (progn
+                 (with-current-buffer buffer
+                   (vterm-send-key "C-c"))
+                 (run-with-timer (if force 0.1 0.5) nil #'finish))
+             (finish))))
+      (if (and observer thread-id turn-id)
+          (condition-case err
+              (progn
+                (magnus-codex--request
+                 observer "turn/interrupt"
+                 `((threadId . ,thread-id) (turnId . ,turn-id))
+                 (lambda (_result error)
+                   (when error
+                     (magnus-codex--insert
+                      instance (format "[turn/interrupt failed] %s\n" error)
+                      'error))
+                   (if error (tui-fallback) (finish))))
+                (run-with-timer (if force 0.1 0.75) nil #'finish))
+            (error
+             (magnus-codex--insert
+              instance
+              (format "[could not request turn interruption] %s\n"
+                      (error-message-string err))
+              'error)
+             (tui-fallback)))
+        (tui-fallback)))))
 
 (defun magnus-codex-running-p (instance)
   "Return non-nil when Codex INSTANCE has a live interactive TUI."
@@ -931,7 +1215,8 @@ Normal interactive approvals are owned and rendered by the TUI itself."
        magnus-codex--instance request-id
        (completing-read
         "Decision: "
-        '("accept" "acceptForSession" "decline" "cancel") nil t)))))
+        '("accept" "acceptForSession" "decline" "cancel") nil t)
+       (plist-get entry :token)))))
 
 (magnus-provider-register
  'codex

--- a/magnus-provider-codex.el
+++ b/magnus-provider-codex.el
@@ -54,6 +54,9 @@ arriving during startup."
 (defconst magnus-codex--session-scan-limit (* 1024 1024)
   "Maximum rollout bytes inspected while identifying a new session.")
 
+(defvar magnus-codex--session-file-cache (make-hash-table :test #'equal)
+  "Codex session-root/session-ID keys to verified rollout file paths.")
+
 (defvar-local magnus-codex--instance nil
   "Magnus instance represented by the current Codex TUI buffer.")
 
@@ -150,7 +153,10 @@ Only the initial metadata and first user message are examined."
                 (when (equal (alist-get 'type event) "user_message")
                   (setq user-message (alist-get 'message event))))
               (forward-line 1))
-            (and (equal user-message prompt) id))))
+            (when (equal user-message prompt)
+              (puthash (cons (magnus-codex--session-root) id) file
+                       magnus-codex--session-file-cache)
+              id))))
     (error
      ;; A concurrently written rollout is retried on the next bounded poll.
      nil)))
@@ -487,6 +493,53 @@ FORCE kills the terminal immediately; otherwise interrupt before closing it."
     (magnus-codex-start instance))
   (pop-to-buffer (magnus-instance-buffer instance)))
 
+(defun magnus-codex-trace-file (instance)
+  "Return the rollout JSONL file for Codex INSTANCE, or nil."
+  (when-let ((session-id (magnus-instance-session-id instance)))
+    (let* ((root (magnus-codex--session-root))
+           (cache-key (cons root session-id))
+           (cached (gethash cache-key magnus-codex--session-file-cache)))
+      (if (and cached (file-exists-p cached))
+          cached
+        (remhash cache-key magnus-codex--session-file-cache)
+        (when (file-directory-p root)
+          (when-let ((file
+                      (car
+                       (directory-files-recursively
+                        root
+                        (concat "rollout-.*-"
+                                (regexp-quote session-id)
+                                "\\.jsonl\\'")))))
+            (puthash cache-key file magnus-codex--session-file-cache)
+            file))))))
+
+(defun magnus-codex--canonical-trace-entry (role timestamp text)
+  "Build a shared trace entry for ROLE, TIMESTAMP, and TEXT."
+  (if (eq role 'user)
+      `((type . "user")
+        (timestamp . ,timestamp)
+        (message . ((content . ,text))))
+    `((type . "assistant")
+      (timestamp . ,timestamp)
+      (message . ((content . [((type . "text") (text . ,text))]))))))
+
+(defun magnus-codex-trace-entry (_instance entry)
+  "Normalize one visible Codex rollout ENTRY for the shared trace viewer.
+Codex `response_item' records are deliberately ignored: assistant output is
+duplicated in `event_msg' records, and raw reasoning content is encrypted."
+  (when (equal (alist-get 'type entry) "event_msg")
+    (let* ((payload (alist-get 'payload entry))
+           (event-type (alist-get 'type payload))
+           (text (alist-get 'message payload))
+           (timestamp (alist-get 'timestamp entry)))
+      (when (and (stringp text) (not (string-empty-p text)))
+        (pcase event-type
+          ("user_message"
+           (magnus-codex--canonical-trace-entry 'user timestamp text))
+          ("agent_message"
+           (magnus-codex--canonical-trace-entry
+            'assistant timestamp text)))))))
+
 (magnus-provider-register
  'codex
  '((start . magnus-codex-start)
@@ -495,7 +548,9 @@ FORCE kills the terminal immediately; otherwise interrupt before closing it."
    (interrupt . magnus-codex-interrupt)
    (stop . magnus-codex-stop)
    (running-p . magnus-codex-running-p)
-   (switch-to . magnus-codex-switch-to)))
+   (switch-to . magnus-codex-switch-to)
+   (trace-file . magnus-codex-trace-file)
+   (trace-entry . magnus-codex-trace-entry)))
 
 (provide 'magnus-provider-codex)
 ;;; magnus-provider-codex.el ends here

--- a/magnus-provider-codex.el
+++ b/magnus-provider-codex.el
@@ -1,0 +1,639 @@
+;;; magnus-provider-codex.el --- Codex App Server provider for Magnus -*- lexical-binding: t -*-
+
+;; Copyright (C) 2026 Hrishikesh S
+;; Author: Hrishikesh S <hrish2006@gmail.com>
+;; Version: 0.1.0
+;; URL: https://github.com/hrishikeshs/magnus
+;; SPDX-License-Identifier: MIT
+
+;;; Commentary:
+
+;; Opt-in Codex support using the versioned App Server JSON-RPC protocol over
+;; stdio.  This module does not alter Magnus's default Claude Code/vterm path.
+;; It provides thread start/resume, turn start/steer/interrupt, streamed agent
+;; messages and plans, and a semantic approval callback surface.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'json)
+(require 'subr-x)
+(require 'magnus-instances)
+(require 'magnus-provider)
+
+(declare-function magnus-status-refresh "magnus-status")
+(defvar magnus-buffer-name)
+
+(defcustom magnus-codex-executable "codex"
+  "Path to the Codex executable used for App Server sessions."
+  :type 'string
+  :group 'magnus)
+
+(defcustom magnus-codex-approval-handler nil
+  "Optional function called for each Codex approval request.
+The function receives INSTANCE, REQUEST-ID, METHOD, and PARAMS.  It may call
+`magnus-codex-respond-approval' immediately or later.  When nil, the request
+remains pending and is displayed in the instance buffer."
+  :type '(choice (const :tag "Queue for manual handling" nil)
+                 (function :tag "Handler function"))
+  :group 'magnus)
+
+(defcustom magnus-codex-extra-developer-instructions nil
+  "Optional extra developer instructions for Magnus-managed Codex threads.
+Magnus always supplies a small provider-neutral coordination preamble."
+  :type '(choice (const :tag "None" nil) string)
+  :group 'magnus)
+
+(defvar magnus-codex-event-hook nil
+  "Hook run after a Codex server event.
+Functions receive INSTANCE, METHOD, and PARAMS.")
+
+(defvar magnus-codex-approval-request-hook nil
+  "Hook run when Codex requests semantic approval.
+Functions receive INSTANCE, REQUEST-ID, METHOD, and PARAMS.  Use
+`magnus-codex-respond-approval' to answer the request.")
+
+(defvar magnus-codex--connections (make-hash-table :test #'equal)
+  "Instance ID to App Server process map.")
+
+(defvar magnus-codex--active-turns (make-hash-table :test #'equal)
+  "Instance ID to active Codex turn ID map.")
+
+(defvar magnus-codex--approvals (make-hash-table :test #'equal)
+  "JSON-RPC request ID to pending approval plist map.")
+
+(defvar-local magnus-codex--instance nil
+  "Codex instance represented by the current output buffer.")
+
+(define-derived-mode magnus-codex-mode special-mode "Magnus-Codex"
+  "Major mode for streamed Codex App Server output."
+  :group 'magnus
+  (setq-local truncate-lines nil)
+  (setq-local word-wrap t))
+
+(let ((map magnus-codex-mode-map))
+  (define-key map (kbd "m") #'magnus-codex-send-message)
+  (define-key map (kbd "a") #'magnus-codex-answer-approval)
+  (define-key map (kbd "C-c C-c") #'magnus-codex-send-message)
+  (define-key map (kbd "C-c C-k") #'magnus-codex-interrupt-current))
+
+(defun magnus-codex--buffer (instance)
+  "Create or return the output buffer for INSTANCE."
+  (let ((buffer (magnus-instance-buffer instance)))
+    (if (buffer-live-p buffer)
+        buffer
+      (setq buffer (get-buffer-create
+                    (format "*codex:%s*" (magnus-instance-name instance))))
+      (with-current-buffer buffer
+        (magnus-codex-mode)
+        (setq-local magnus-codex--instance instance)
+        (let ((inhibit-read-only t))
+          (erase-buffer)
+          (insert (format "Codex agent: %s\nDirectory: %s\n\n"
+                          (magnus-instance-name instance)
+                          (magnus-instance-directory instance)))))
+      (magnus-instances-update instance :buffer buffer)
+      buffer)))
+
+(defun magnus-codex--insert (instance text &optional face)
+  "Append TEXT to INSTANCE's output buffer, optionally using FACE."
+  (let ((buffer (magnus-codex--buffer instance)))
+    (when (buffer-live-p buffer)
+      (with-current-buffer buffer
+        (let ((inhibit-read-only t)
+              (moving (= (point) (point-max))))
+          (goto-char (point-max))
+          (insert (if face (propertize text 'face face) text))
+          (when moving (goto-char (point-max))))))))
+
+(defun magnus-codex--connection (instance)
+  "Return the live App Server process for INSTANCE, or nil."
+  (let ((process (gethash (magnus-instance-id instance)
+                          magnus-codex--connections)))
+    (and (process-live-p process) process)))
+
+(defun magnus-codex--json (object)
+  "Serialize OBJECT as compact JSON."
+  (json-serialize object :null-object nil :false-object :json-false))
+
+(defun magnus-codex--send-object (process object)
+  "Send JSON-RPC OBJECT followed by a newline to PROCESS."
+  (unless (process-live-p process)
+    (user-error "Codex App Server is not running"))
+  (process-send-string process (concat (magnus-codex--json object) "\n")))
+
+(defun magnus-codex--request (process method params callback)
+  "Send METHOD request with PARAMS through PROCESS and register CALLBACK.
+CALLBACK receives RESULT and ERROR, exactly one of which is non-nil."
+  (let* ((next (1+ (or (process-get process 'magnus-codex-next-id) 0)))
+         (pending (process-get process 'magnus-codex-pending)))
+    (process-put process 'magnus-codex-next-id next)
+    (puthash next callback pending)
+    (magnus-codex--send-object
+     process `((jsonrpc . "2.0") (id . ,next) (method . ,method)
+               (params . ,params)))
+    next))
+
+(defun magnus-codex--notify (process method &optional params)
+  "Send METHOD notification and optional PARAMS through PROCESS."
+  (magnus-codex--send-object
+   process (append `((jsonrpc . "2.0") (method . ,method))
+                   (when params `((params . ,params))))))
+
+(defun magnus-codex--parse-line (line)
+  "Parse one JSON-RPC LINE into an alist."
+  (json-parse-string line :object-type 'alist :array-type 'list
+                     :null-object nil :false-object :json-false))
+
+(defun magnus-codex--filter (process output)
+  "Consume newline-delimited JSON-RPC OUTPUT from PROCESS."
+  (let* ((partial (concat (or (process-get process 'magnus-codex-partial) "")
+                          output))
+         (lines (split-string partial "\n"))
+         (complete (butlast lines))
+         (remainder (car (last lines))))
+    (process-put process 'magnus-codex-partial remainder)
+    (dolist (line complete)
+      (unless (string-empty-p line)
+        (condition-case err
+            (magnus-codex--dispatch-message
+             process (magnus-codex--parse-line line))
+          (error
+           (when-let ((instance (process-get process 'magnus-codex-instance)))
+             (magnus-codex--insert
+              instance
+              (format "\n[protocol error] %s\n" (error-message-string err))
+              'error))))))))
+
+(defun magnus-codex--dispatch-message (process message)
+  "Dispatch parsed JSON-RPC MESSAGE received from PROCESS."
+  (let ((id (alist-get 'id message))
+        (method (alist-get 'method message))
+        (params (alist-get 'params message)))
+    (cond
+     ((and method id)
+      (magnus-codex--handle-server-request process id method params))
+     (method
+      (magnus-codex--handle-notification process method params))
+     (id
+      (let* ((pending (process-get process 'magnus-codex-pending))
+             (callback (gethash id pending)))
+        (when callback
+          (remhash id pending)
+          (funcall callback (alist-get 'result message)
+                   (alist-get 'error message))))))))
+
+(defun magnus-codex--approval-method-p (method)
+  "Return non-nil when METHOD is a supported approval request."
+  (member method '("item/commandExecution/requestApproval"
+                   "item/fileChange/requestApproval"
+                   "item/permissions/requestApproval")))
+
+(defun magnus-codex--handle-server-request (process id method params)
+  "Handle server request ID METHOD PARAMS from PROCESS."
+  (let ((instance (process-get process 'magnus-codex-instance)))
+    (if (magnus-codex--approval-method-p method)
+        (progn
+          (puthash id (list :instance instance :process process
+                            :method method :params params)
+                   magnus-codex--approvals)
+          (magnus-codex--insert
+           instance
+           (format "\n[approval pending] %s\n%s\n"
+                   method (magnus-codex--approval-summary params))
+           'warning)
+          (run-hook-with-args 'magnus-codex-approval-request-hook
+                              instance id method params)
+          (when magnus-codex-approval-handler
+            (run-at-time 0 nil magnus-codex-approval-handler
+                         instance id method params)))
+      (magnus-codex--insert instance
+                            (format "\n[unsupported server request] %s\n"
+                                    method)
+                            'warning)
+      (magnus-codex--send-object
+       process `((jsonrpc . "2.0") (id . ,id)
+                 (error . ((code . -32601)
+                           (message . "Unsupported server request"))))))))
+
+(defun magnus-codex--approval-summary (params)
+  "Return a readable summary of approval PARAMS."
+  (string-join
+   (delq nil
+         (list (when-let ((command (alist-get 'command params))) command)
+               (when-let ((cwd (alist-get 'cwd params)))
+                 (format "cwd: %s" cwd))
+               (when-let ((reason (alist-get 'reason params))) reason)))
+   "\n"))
+
+(defun magnus-codex-respond-approval (instance request-id decision)
+  "Respond to INSTANCE approval REQUEST-ID with DECISION.
+DECISION is normally accept, acceptForSession, decline, or cancel.  A
+permission-profile request instead requires its complete response alist."
+  (let* ((entry (gethash request-id magnus-codex--approvals))
+         (owner (plist-get entry :instance))
+         (process (plist-get entry :process))
+         (method (plist-get entry :method))
+         (result (if (equal method "item/permissions/requestApproval")
+                     decision
+                   `((decision . ,decision)))))
+    (unless (and entry (eq owner instance))
+      (user-error "No pending Codex approval %s for this instance" request-id))
+    (when (and (equal method "item/permissions/requestApproval")
+               (not (and (listp decision)
+                         (alist-get 'permissions decision))))
+      (user-error "Permission approval requires a response alist with permissions"))
+    (when (and (not (equal method "item/permissions/requestApproval"))
+               (not (member decision
+                            '("accept" "acceptForSession" "decline" "cancel"))))
+      (user-error "Unsupported Codex approval decision: %s" decision))
+    (magnus-codex--send-object
+     process `((jsonrpc . "2.0") (id . ,request-id)
+               (result . ,result)))
+    (remhash request-id magnus-codex--approvals)
+    (magnus-codex--insert instance
+                          (format "[approval answered: %s]\n" decision)
+                          'font-lock-comment-face)))
+
+(defun magnus-codex--turn-id (turn)
+  "Extract an ID from TURN."
+  (and (listp turn) (alist-get 'id turn)))
+
+(defun magnus-codex--handle-notification (process method params)
+  "Handle METHOD notification with PARAMS from PROCESS."
+  (let ((instance (process-get process 'magnus-codex-instance)))
+    (pcase method
+      ("item/agentMessage/delta"
+       (magnus-codex--insert instance (or (alist-get 'delta params) "")))
+      ("turn/plan/updated"
+       (magnus-codex--insert instance
+                             (magnus-codex--format-plan params)
+                             'font-lock-comment-face))
+      ("turn/started"
+       (let ((turn-id (magnus-codex--turn-id (alist-get 'turn params))))
+         (when turn-id
+           (puthash (magnus-instance-id instance) turn-id
+                    magnus-codex--active-turns)))
+       (magnus-codex--insert instance "\n[turn started]\n"
+                             'font-lock-comment-face))
+      ("turn/completed"
+       (remhash (magnus-instance-id instance) magnus-codex--active-turns)
+       (magnus-codex--insert instance "\n[turn completed]\n\n"
+                             'font-lock-comment-face))
+      ("thread/status/changed"
+       (magnus-codex--insert
+        instance (format "\n[status: %s]\n"
+                         (magnus-codex--thread-status-name
+                          (alist-get 'status params)))
+        'font-lock-comment-face))
+      ("error"
+       (magnus-codex--insert instance
+                             (format "\n[Codex error] %s\n"
+                                     (or (alist-get 'message
+                                                    (alist-get 'error params))
+                                         params))
+                             'error)))
+    (run-hook-with-args 'magnus-codex-event-hook instance method params)))
+
+(defun magnus-codex--thread-status-name (status)
+  "Return the readable type name from App Server STATUS."
+  (if (listp status)
+      (or (alist-get 'type status) "unknown")
+    (or status "unknown")))
+
+(defun magnus-codex--format-plan (params)
+  "Format plan notification PARAMS for the output buffer."
+  (concat
+   "\n[plan]\n"
+   (mapconcat
+    (lambda (step)
+      (format "  %-11s %s" (or (alist-get 'status step) "")
+              (or (alist-get 'step step) "")))
+    (alist-get 'plan params) "\n")
+   "\n"))
+
+(defun magnus-codex--sentinel (process event)
+  "Handle PROCESS termination EVENT."
+  (unless (process-live-p process)
+    (when-let ((instance (process-get process 'magnus-codex-instance)))
+      (remhash (magnus-instance-id instance) magnus-codex--connections)
+      (remhash (magnus-instance-id instance) magnus-codex--active-turns)
+      (magnus-codex--clear-approvals instance)
+      (unless (eq (magnus-instance-status instance) 'purged)
+        (magnus-instances-update instance :status 'stopped))
+      (unless (process-get process 'magnus-codex-intentional-stop)
+        (magnus-codex--insert instance (format "\n[App Server %s]" event)
+                              'font-lock-comment-face))
+      (when (and (boundp 'magnus-buffer-name)
+                 (get-buffer magnus-buffer-name))
+        (magnus-status-refresh)))))
+
+(defun magnus-codex--clear-approvals (instance)
+  "Remove pending approvals owned by INSTANCE."
+  (let (request-ids)
+    (maphash
+     (lambda (request-id entry)
+       (when (eq (plist-get entry :instance) instance)
+         (push request-id request-ids)))
+     magnus-codex--approvals)
+    (dolist (request-id request-ids)
+      (remhash request-id magnus-codex--approvals))))
+
+(defun magnus-codex--start-process (instance)
+  "Start a Codex App Server process for INSTANCE."
+  (let* ((name (format "magnus-codex-%s" (magnus-instance-id instance)))
+         (stderr (get-buffer-create (format " *%s-stderr*" name)))
+         (default-directory (magnus-instance-directory instance))
+         (process (make-process
+                   :name name
+                   :command (list magnus-codex-executable
+                                  "app-server" "--stdio")
+                   :connection-type 'pipe
+                   :coding 'utf-8-unix
+                   :noquery t
+                   :buffer nil
+                   :stderr stderr
+                   :filter #'magnus-codex--filter
+                   :sentinel #'magnus-codex--sentinel)))
+    (process-put process 'magnus-codex-instance instance)
+    (process-put process 'magnus-codex-pending (make-hash-table :test #'equal))
+    (process-put process 'magnus-codex-next-id 0)
+    (process-put process 'magnus-codex-partial "")
+    (puthash (magnus-instance-id instance) process magnus-codex--connections)
+    process))
+
+(defun magnus-codex-start (instance &optional initial-message)
+  "Start or resume Codex INSTANCE, then optionally send INITIAL-MESSAGE."
+  (when (magnus-codex--connection instance)
+    (user-error "Codex instance `%s' is already running"
+                (magnus-instance-name instance)))
+  (magnus-codex--buffer instance)
+  (let ((process (magnus-codex--start-process instance)))
+    (magnus-codex--request
+     process "initialize"
+     '((clientInfo . ((name . "magnus") (title . "Magnus")
+                      (version . "0.1.0")))
+       (capabilities . ((experimentalApi . :json-false))))
+     (lambda (_result error)
+       (if error
+           (progn
+             (magnus-codex--insert instance
+                                   (format "[initialize failed] %s\n" error)
+                                   'error)
+             (delete-process process))
+         (magnus-codex--notify process "initialized")
+         (magnus-codex--open-thread process instance initial-message))))
+    process))
+
+(defun magnus-codex--open-thread (process instance initial-message)
+  "Start or resume INSTANCE thread on PROCESS, then send INITIAL-MESSAGE."
+  (let* ((thread-id (magnus-instance-session-id instance))
+         (method (if thread-id "thread/resume" "thread/start"))
+         (common `((cwd . ,(magnus-instance-directory instance))
+                   (developerInstructions . ,(magnus-codex--instructions instance))))
+         (params (if thread-id
+                     (cons `(threadId . ,thread-id) common)
+                   common)))
+    (magnus-codex--request
+     process method params
+     (lambda (result error)
+       (if error
+           (progn
+             (magnus-codex--insert instance
+                                   (format "[%s failed] %s\n" method error)
+                                   'error)
+             (magnus-instances-update instance :status 'stopped)
+             (delete-process process))
+         (let ((new-id (alist-get 'id (alist-get 'thread result))))
+           (when new-id
+             (magnus-instances-update instance :session-id new-id))
+           (magnus-instances-update instance :status 'running)
+           (magnus-codex--insert instance
+                                 (format "[thread %s: %s]\n\n"
+                                         (if thread-id "resumed" "started")
+                                         (or new-id thread-id))
+                                 'font-lock-comment-face)
+           (when initial-message
+             (magnus-codex-send instance initial-message))))))))
+
+(defun magnus-codex--instructions (instance)
+  "Build Magnus identity and coordination instructions for Codex INSTANCE."
+  (let* ((name (magnus-instance-name instance))
+         (directory (magnus-instance-directory instance))
+         (memory-relative (format ".claude/agents/%s/memory.md" name))
+         (memory-file (expand-file-name memory-relative directory))
+         (returning (file-exists-p memory-file)))
+    (concat
+     (format "You are %s, a Magnus-managed Codex agent. " name)
+     (if returning
+         (format
+          (concat "You have been here before. Before anything else, read %s. "
+                  "It is your own prior voice: decisions you made, patterns "
+                  "you found, relationships, and unfinished work.\n\n")
+          memory-relative)
+       (format
+        (concat "This is your first session under this identity. Your home is "
+                ".claude/agents/%s/. Before signing off, create %s as a "
+                "first-person letter to future-you, not a status report.\n\n")
+        name memory-relative))
+
+     "Magnus may be running several agents in this project. Get oriented before "
+     "changing files:\n"
+     "1. Read .magnus-coord.md when it exists. Review Active Work, Discoveries, "
+     "Decisions, and the recent Log.\n"
+     "2. Check for overlapping file claims. Discuss conflicts in the Log before "
+     "editing, then announce your plan and claim the files you expect to touch.\n"
+     "3. Read relevant project instructions and inspect existing work before "
+     "choosing an implementation.\n\n"
+
+     "While working:\n"
+     "- Check .magnus-coord.md periodically. Use @mentions to reach teammates.\n"
+     "- Put non-obvious facts and gotchas in Discoveries so peers do not have to "
+     "rediscover them. Put shared architectural choices in Decisions.\n"
+     "- Create .claude/agents/" name "/busy when you need uninterrupted focus; "
+     "remove it when that focus period ends.\n"
+     "- Other agents' first-person memories live under .claude/agents/. Read a "
+     "relevant one when prior context or expertise would save work.\n"
+     "- Before requesting user attention, log [ATTENTION] with the reason; log "
+     "when it is resolved so agents can serialize interruptions.\n"
+     "- Do not overwrite another agent's Active Work row or assume permission to "
+     "commit, push, deploy, or perform unrelated changes.\n\n"
+
+     "When finishing:\n"
+     "1. Release or mark your Active Work row done and log what finished.\n"
+     "2. Record useful discoveries and decisions.\n"
+     "3. Update " memory-relative " in first person: what you learned, why you "
+     "chose this approach, relationships, and what remains.\n"
+     "4. When a commit is authorized, preserve the why, tradeoffs, and gotchas in "
+     "its message; the coordination log is ephemeral.\n\n"
+
+     "Thinking out loud:\n"
+     "For every user-facing message, put a candid visible working notebook inside "
+     "[thinking]...[end-thinking], followed by the answer inside "
+     "[response]...[end-response]. The notebook is valuable before the conclusion "
+     "is polished: state the current hypothesis, evidence, uncertainty, plausible "
+     "branches, constraints, contradictions, dead ends, and corrections as they "
+     "become relevant. If a new fact reverses the plan, say so and explain why. "
+     "Avoid empty narration such as 'I will inspect the code.' Do not claim this "
+     "reveals private hidden chain-of-thought; it is an explicit collaborative "
+     "engineering journal written for the user.\n\n"
+
+     "Begin by orienting and reading your memory when present, then handle the "
+     "user's task."
+     (when magnus-codex-extra-developer-instructions
+       (concat "\n\n" magnus-codex-extra-developer-instructions)))))
+
+(defun magnus-codex--input (text)
+  "Build App Server user input for TEXT."
+  `[((type . "text") (text . ,text))])
+
+(defun magnus-codex-send (instance text)
+  "Send TEXT to Codex INSTANCE, steering when a turn is active."
+  (if-let ((turn-id (gethash (magnus-instance-id instance)
+                             magnus-codex--active-turns)))
+      (magnus-codex-steer instance text turn-id)
+    (let ((process (or (magnus-codex--connection instance)
+                       (user-error "Codex instance is not running")))
+          (thread-id (or (magnus-instance-session-id instance)
+                         (user-error "Codex thread is not ready yet"))))
+      (magnus-codex--insert instance (format "\nYou: %s\n\n" text)
+                            'font-lock-keyword-face)
+      (magnus-codex--request
+       process "turn/start"
+       `((threadId . ,thread-id) (input . ,(magnus-codex--input text)))
+       (lambda (result error)
+         (if error
+             (magnus-codex--insert instance
+                                   (format "[turn/start failed] %s\n" error)
+                                   'error)
+           (let ((turn-id (magnus-codex--turn-id (alist-get 'turn result))))
+             (when turn-id
+               (puthash (magnus-instance-id instance) turn-id
+                        magnus-codex--active-turns)))))))))
+
+(defun magnus-codex-steer (instance text &optional expected-turn-id)
+  "Steer active Codex INSTANCE turn with TEXT.
+EXPECTED-TURN-ID defaults to INSTANCE's current active turn."
+  (let ((process (or (magnus-codex--connection instance)
+                     (user-error "Codex instance is not running")))
+        (thread-id (or (magnus-instance-session-id instance)
+                       (user-error "Codex thread is not ready yet")))
+        (turn-id (or expected-turn-id
+                     (gethash (magnus-instance-id instance)
+                              magnus-codex--active-turns)
+                     (user-error "Codex has no active turn to steer"))))
+    (magnus-codex--insert instance (format "\nYou (steer): %s\n\n" text)
+                          'font-lock-keyword-face)
+    (magnus-codex--request
+     process "turn/steer"
+     `((threadId . ,thread-id) (expectedTurnId . ,turn-id)
+       (input . ,(magnus-codex--input text)))
+     (lambda (_result error)
+       (when error
+         (magnus-codex--insert instance
+                               (format "[turn/steer failed] %s\n" error)
+                               'error))))))
+
+(defun magnus-codex-interrupt (instance)
+  "Interrupt the active turn for Codex INSTANCE."
+  (let ((process (or (magnus-codex--connection instance)
+                     (user-error "Codex instance is not running")))
+        (thread-id (or (magnus-instance-session-id instance)
+                       (user-error "Codex thread is not ready yet")))
+        (turn-id (or (gethash (magnus-instance-id instance)
+                              magnus-codex--active-turns)
+                     (user-error "Codex has no active turn"))))
+    (magnus-codex--request
+     process "turn/interrupt"
+     `((threadId . ,thread-id) (turnId . ,turn-id))
+     (lambda (_result error)
+       (if error
+           (magnus-codex--insert instance
+                                 (format "[interrupt failed] %s\n" error)
+                                 'error)
+         (remhash (magnus-instance-id instance) magnus-codex--active-turns)
+         (magnus-codex--insert instance "[turn interrupted]\n"
+                               'font-lock-comment-face))))))
+
+(defun magnus-codex-stop (instance &optional force)
+  "Stop Codex INSTANCE App Server process.
+When FORCE is non-nil, kill it immediately."
+  (let ((buffer (magnus-instance-buffer instance)))
+    (when-let ((process (magnus-codex--connection instance)))
+      (process-put process 'magnus-codex-intentional-stop t)
+      (if force (kill-process process) (delete-process process)))
+    (when (buffer-live-p buffer)
+      (kill-buffer buffer)))
+  (remhash (magnus-instance-id instance) magnus-codex--connections)
+  (remhash (magnus-instance-id instance) magnus-codex--active-turns)
+  (magnus-instances-update instance :status 'stopped :buffer nil))
+
+(defun magnus-codex-running-p (instance)
+  "Return non-nil if Codex INSTANCE has a live App Server connection."
+  (and (magnus-codex--connection instance) t))
+
+(defun magnus-codex-switch-to (instance)
+  "Switch to Codex INSTANCE, resuming its thread when necessary."
+  (unless (magnus-codex-running-p instance)
+    (magnus-codex-start instance))
+  (pop-to-buffer (magnus-codex--buffer instance)))
+
+(defun magnus-codex-send-message ()
+  "Prompt for and send a message from a Codex output buffer."
+  (interactive)
+  (unless magnus-codex--instance
+    (user-error "This is not a Magnus Codex buffer"))
+  (let ((text (read-string (format "Message to %s: "
+                                   (magnus-instance-name
+                                    magnus-codex--instance)))))
+    (unless (string-empty-p text)
+      (magnus-codex-send magnus-codex--instance text))))
+
+(defun magnus-codex-interrupt-current ()
+  "Interrupt the Codex instance represented by the current buffer."
+  (interactive)
+  (unless magnus-codex--instance
+    (user-error "This is not a Magnus Codex buffer"))
+  (magnus-codex-interrupt magnus-codex--instance))
+
+(defun magnus-codex-answer-approval ()
+  "Answer a pending command or file approval in the current Codex buffer."
+  (interactive)
+  (unless magnus-codex--instance
+    (user-error "This is not a Magnus Codex buffer"))
+  (let (requests)
+    (maphash
+     (lambda (request-id entry)
+       (when (eq (plist-get entry :instance) magnus-codex--instance)
+         (push (cons (format "%s: %s" request-id (plist-get entry :method))
+                     request-id)
+               requests)))
+     magnus-codex--approvals)
+    (unless requests
+      (user-error "This Codex instance has no pending approvals"))
+    (let* ((label (if (= (length requests) 1)
+                      (caar requests)
+                    (completing-read "Approval: " requests nil t)))
+           (request-id (cdr (assoc label requests)))
+           (entry (gethash request-id magnus-codex--approvals)))
+      (when (equal (plist-get entry :method) "item/permissions/requestApproval")
+        (user-error "Permission-profile approvals require a custom approval handler"))
+      (magnus-codex-respond-approval
+       magnus-codex--instance request-id
+       (completing-read
+        "Decision: "
+        '("accept" "acceptForSession" "decline" "cancel") nil t)))))
+
+(magnus-provider-register
+ 'codex
+ '((start . magnus-codex-start)
+   (resume . magnus-codex-start)
+   (send . magnus-codex-send)
+   (steer . magnus-codex-steer)
+   (interrupt . magnus-codex-interrupt)
+   (stop . magnus-codex-stop)
+   (running-p . magnus-codex-running-p)
+   (switch-to . magnus-codex-switch-to)))
+
+(provide 'magnus-provider-codex)
+;;; magnus-provider-codex.el ends here

--- a/magnus-provider-codex.el
+++ b/magnus-provider-codex.el
@@ -72,17 +72,61 @@ Functions receive INSTANCE, REQUEST-ID, METHOD, and PARAMS.  Use
 (defvar-local magnus-codex--instance nil
   "Codex instance represented by the current output buffer.")
 
-(define-derived-mode magnus-codex-mode special-mode "Magnus-Codex"
+(defvar-local magnus-codex--prompt-marker nil
+  "Marker at the beginning of the inline Codex prompt.")
+
+(defvar-local magnus-codex--input-marker nil
+  "Marker at the beginning of editable inline Codex input.")
+
+(defun magnus-codex-enable-inline-input ()
+  "Protect the current transcript and add an editable inline prompt."
+  (interactive)
+  (let ((inhibit-read-only t))
+    (setq buffer-read-only nil)
+    (unless (and (markerp magnus-codex--prompt-marker)
+                 (marker-position magnus-codex--prompt-marker)
+                 (markerp magnus-codex--input-marker)
+                 (marker-position magnus-codex--input-marker))
+      (add-text-properties
+       (point-min) (point-max)
+       '(read-only t rear-nonsticky (read-only face)))
+      (goto-char (point-max))
+      (unless (bolp)
+        (insert (propertize "\n" 'read-only t)))
+      (let ((prompt-start (point)))
+        (insert (propertize "> "
+                            'read-only t
+                            'face 'font-lock-keyword-face
+                            'front-sticky '(read-only face)
+                            'rear-nonsticky '(read-only face)))
+        (setq magnus-codex--prompt-marker
+              (copy-marker prompt-start t))
+        (setq magnus-codex--input-marker (copy-marker (point) nil))))
+    (goto-char (point-max))))
+
+(define-derived-mode magnus-codex-mode fundamental-mode "Magnus-Codex"
   "Major mode for streamed Codex App Server output."
   :group 'magnus
+  (setq buffer-read-only nil)
   (setq-local truncate-lines nil)
-  (setq-local word-wrap t))
+  (setq-local word-wrap t)
+  (magnus-codex-enable-inline-input))
 
 (let ((map magnus-codex-mode-map))
-  (define-key map (kbd "m") #'magnus-codex-send-message)
-  (define-key map (kbd "a") #'magnus-codex-answer-approval)
-  (define-key map (kbd "C-c C-c") #'magnus-codex-send-message)
-  (define-key map (kbd "C-c C-k") #'magnus-codex-interrupt-current))
+  ;; Older builds derived this mode from `special-mode'; reset the parent so
+  ;; reloading the provider makes printable keys self-insert immediately.
+  (set-keymap-parent map nil)
+  (define-key map (kbd "C-c m") #'magnus-codex-send-message)
+  (define-key map (kbd "C-c a") #'magnus-codex-answer-approval)
+  (define-key map (kbd "RET") #'magnus-codex-submit-input)
+  (define-key map (kbd "<return>") #'magnus-codex-submit-input)
+  (define-key map (kbd "C-c C-c") #'magnus-codex-submit-input)
+  (define-key map (kbd "C-c C-k") #'magnus-codex-interrupt-current)
+  (define-key map (kbd "DEL") #'magnus-codex-backward-delete)
+  (define-key map (kbd "<backspace>") #'magnus-codex-backward-delete)
+  (define-key map (kbd "C-a") #'magnus-codex-beginning-of-input)
+  (define-key map [remap self-insert-command] #'magnus-codex-self-insert)
+  (define-key map [remap yank] #'magnus-codex-yank))
 
 (defun magnus-codex--buffer (instance)
   "Create or return the output buffer for INSTANCE."
@@ -96,9 +140,16 @@ Functions receive INSTANCE, REQUEST-ID, METHOD, and PARAMS.  Use
         (setq-local magnus-codex--instance instance)
         (let ((inhibit-read-only t))
           (erase-buffer)
+          (when (markerp magnus-codex--prompt-marker)
+            (set-marker magnus-codex--prompt-marker nil))
+          (when (markerp magnus-codex--input-marker)
+            (set-marker magnus-codex--input-marker nil))
+          (setq magnus-codex--prompt-marker nil
+                magnus-codex--input-marker nil)
           (insert (format "Codex agent: %s\nDirectory: %s\n\n"
                           (magnus-instance-name instance)
-                          (magnus-instance-directory instance)))))
+                          (magnus-instance-directory instance))))
+        (magnus-codex-enable-inline-input))
       (magnus-instances-update instance :buffer buffer)
       buffer)))
 
@@ -107,11 +158,62 @@ Functions receive INSTANCE, REQUEST-ID, METHOD, and PARAMS.  Use
   (let ((buffer (magnus-codex--buffer instance)))
     (when (buffer-live-p buffer)
       (with-current-buffer buffer
+        (unless (and (markerp magnus-codex--prompt-marker)
+                     (marker-position magnus-codex--prompt-marker))
+          (magnus-codex-enable-inline-input))
         (let ((inhibit-read-only t)
               (moving (= (point) (point-max))))
-          (goto-char (point-max))
-          (insert (if face (propertize text 'face face) text))
+          (goto-char magnus-codex--prompt-marker)
+          (let ((start (point)))
+            (insert text)
+            (add-text-properties
+             start (point)
+             (append '(read-only t rear-nonsticky (read-only face))
+                     (when face (list 'face face)))))
           (when moving (goto-char (point-max))))))))
+
+(defun magnus-codex-self-insert (count)
+  "Insert the typed character COUNT times in the inline input field."
+  (interactive "p")
+  (magnus-codex-enable-inline-input)
+  (goto-char (point-max))
+  (self-insert-command count))
+
+(defun magnus-codex-yank ()
+  "Yank at the end of the inline input field."
+  (interactive)
+  (magnus-codex-enable-inline-input)
+  (goto-char (point-max))
+  (call-interactively #'yank))
+
+(defun magnus-codex-beginning-of-input ()
+  "Move to the beginning of the editable inline input field."
+  (interactive)
+  (magnus-codex-enable-inline-input)
+  (goto-char magnus-codex--input-marker))
+
+(defun magnus-codex-backward-delete (count)
+  "Delete COUNT characters backward within the inline input field."
+  (interactive "p")
+  (magnus-codex-enable-inline-input)
+  (goto-char (point-max))
+  (let ((available (- (point) magnus-codex--input-marker)))
+    (when (> available 0)
+      (delete-region (- (point) (min count available)) (point)))))
+
+(defun magnus-codex-submit-input ()
+  "Submit editable inline input to the current Codex instance."
+  (interactive)
+  (unless magnus-codex--instance
+    (user-error "This is not a Magnus Codex buffer"))
+  (magnus-codex-enable-inline-input)
+  (let ((text (string-trim
+               (buffer-substring-no-properties
+                magnus-codex--input-marker (point-max)))))
+    (unless (string-empty-p text)
+      (let ((inhibit-read-only t))
+        (delete-region magnus-codex--input-marker (point-max)))
+      (magnus-codex-send magnus-codex--instance text))))
 
 (defun magnus-codex--connection (instance)
   "Return the live App Server process for INSTANCE, or nil."

--- a/magnus-provider-codex.el
+++ b/magnus-provider-codex.el
@@ -54,8 +54,14 @@ arriving during startup."
 (defconst magnus-codex--session-scan-limit (* 1024 1024)
   "Maximum rollout bytes inspected while identifying a new session.")
 
+(defconst magnus-codex--metadata-scan-limit (* 64 1024)
+  "Maximum rollout bytes inspected while reading session metadata.")
+
 (defvar magnus-codex--session-file-cache (make-hash-table :test #'equal)
-  "Codex session-root/session-ID keys to verified rollout file paths.")
+  "Codex session-root/session-ID keys to captured root rollout paths.")
+
+(defvar magnus-codex--trace-file-cache (make-hash-table :test #'equal)
+  "Codex session-root/session-ID keys to active trace rollout state.")
 
 (defvar-local magnus-codex--instance nil
   "Magnus instance represented by the current Codex TUI buffer.")
@@ -125,6 +131,44 @@ arriving during startup."
       (file-error
        (equal (directory-file-name (expand-file-name first))
               (directory-file-name (expand-file-name second)))))))
+
+(defun magnus-codex--rollout-session-id (file)
+  "Return the stable session ID from FILE's first metadata record."
+  (condition-case nil
+      (with-temp-buffer
+        (insert-file-contents file nil 0 magnus-codex--metadata-scan-limit)
+        (goto-char (point-min))
+        (let* ((metadata (magnus-codex--read-json-line))
+               (payload (and (equal (alist-get 'type metadata) "session_meta")
+                             (alist-get 'payload metadata))))
+          (alist-get 'session_id payload)))
+    (error
+     ;; A newly created continuation may not have a complete first line yet.
+     nil)))
+
+(defun magnus-codex--file-modification-time (file)
+  "Return FILE's modification time, or the epoch when FILE vanished."
+  (condition-case nil
+      (or (file-attribute-modification-time (file-attributes file))
+          (seconds-to-time 0))
+    (file-error (seconds-to-time 0))))
+
+(defun magnus-codex--scan-trace-rollouts (files session-id after)
+  "Scan FILES for the newest SESSION-ID rollout modified at or after AFTER.
+Return a cons of the matching file and the latest modification time seen."
+  (let (matching matching-time (latest-time after))
+    (dolist (file files)
+      (let ((modified (magnus-codex--file-modification-time file)))
+        (when (or (null latest-time) (time-less-p latest-time modified))
+          (setq latest-time modified))
+        (when (and (or (null after) (not (time-less-p modified after)))
+                   (equal (magnus-codex--rollout-session-id file) session-id)
+                   (or (null matching-time)
+                       (time-less-p matching-time modified)
+                       (and (not (time-less-p modified matching-time))
+                            (string> file matching))))
+          (setq matching file matching-time modified))))
+    (cons matching latest-time)))
 
 (defun magnus-codex--session-id-from-file (file directory prompt)
   "Return FILE's top-level Codex session ID for DIRECTORY and PROMPT.
@@ -494,24 +538,54 @@ FORCE kills the terminal immediately; otherwise interrupt before closing it."
   (pop-to-buffer (magnus-instance-buffer instance)))
 
 (defun magnus-codex-trace-file (instance)
-  "Return the rollout JSONL file for Codex INSTANCE, or nil."
+  "Return the newest rollout JSONL file for Codex INSTANCE, or nil.
+Root rollout filenames contain the stable session ID, but continuation
+filenames contain a new per-launch ID.  Continuations are therefore matched
+through their first `session_meta.session_id' record."
   (when-let ((session-id (magnus-instance-session-id instance)))
     (let* ((root (magnus-codex--session-root))
            (cache-key (cons root session-id))
-           (cached (gethash cache-key magnus-codex--session-file-cache)))
-      (if (and cached (file-exists-p cached))
-          cached
-        (remhash cache-key magnus-codex--session-file-cache)
-        (when (file-directory-p root)
-          (when-let ((file
-                      (car
-                       (directory-files-recursively
-                        root
-                        (concat "rollout-.*-"
-                                (regexp-quote session-id)
-                                "\\.jsonl\\'")))))
-            (puthash cache-key file magnus-codex--session-file-cache)
-            file))))))
+           (state (gethash cache-key magnus-codex--trace-file-cache))
+           (cached (plist-get state :file))
+           (scan-time (plist-get state :scan-time)))
+      (unless (and cached (file-exists-p cached))
+        (setq cached nil scan-time nil)
+        (remhash cache-key magnus-codex--trace-file-cache))
+      (when (file-directory-p root)
+        (let* ((files
+                (condition-case nil
+                    (if cached
+                        ;; A continuation is always created in a current date
+                        ;; directory.  Full traversal is only needed once.
+                        (magnus-codex--session-files)
+                      (directory-files-recursively
+                       root "rollout-.*\\.jsonl\\'"))
+                  (file-error nil)))
+               (root-pattern
+                (concat "-" (regexp-quote session-id) "\\.jsonl\\'"))
+               (filename-root
+                (and (not cached)
+                     (cl-find-if
+                      (lambda (file) (string-match-p root-pattern file))
+                      files)))
+               (fallback (or cached filename-root))
+               (threshold
+                (or scan-time
+                    (and fallback
+                         (magnus-codex--file-modification-time fallback))))
+               (scan (magnus-codex--scan-trace-rollouts
+                      files session-id threshold))
+               (matching (car scan))
+               (selected (or matching fallback))
+               (latest-time (cdr scan)))
+          (if selected
+              (progn
+                (puthash cache-key
+                         (list :file selected :scan-time latest-time)
+                         magnus-codex--trace-file-cache)
+                selected)
+            (remhash cache-key magnus-codex--trace-file-cache)
+            nil))))))
 
 (defun magnus-codex--canonical-trace-entry (role timestamp text)
   "Build a shared trace entry for ROLE, TIMESTAMP, and TEXT."

--- a/magnus-provider-codex.el
+++ b/magnus-provider-codex.el
@@ -8,10 +8,11 @@
 
 ;;; Commentary:
 
-;; Opt-in Codex support using the versioned App Server JSON-RPC protocol over
-;; stdio.  This module does not alter Magnus's default Claude Code/vterm path.
-;; It provides thread start/resume, turn start/steer/interrupt, streamed agent
-;; messages and plans, and a semantic approval callback surface.
+;; Opt-in Codex support with a real Codex TUI in a vterm buffer.  A lightweight
+;; JSON-RPC observer connects through `codex app-server proxy' to the managed
+;; local daemon, while the TUI is the sole interactive writer for the thread.
+;; This preserves native input, approvals, rendering, and session resurrection
+;; without starting one App Server per Magnus agent.
 
 ;;; Code:
 
@@ -22,6 +23,11 @@
 (require 'magnus-provider)
 
 (declare-function magnus-status-refresh "magnus-status")
+(declare-function magnus-process--create-vterm-buffer "magnus-process"
+                  (buffer-name))
+(declare-function vterm-send-key "vterm" (key &optional shift meta ctrl))
+(declare-function vterm-send-return "vterm" ())
+(declare-function vterm-send-string "vterm" (string &optional paste-p))
 (defvar magnus-buffer-name)
 
 (defcustom magnus-codex-executable "codex"
@@ -44,14 +50,10 @@ Magnus always supplies a small provider-neutral coordination preamble."
   :type '(choice (const :tag "None" nil) string)
   :group 'magnus)
 
-(defcustom magnus-codex-active-turn-delivery 'queue
-  "How `magnus-codex-send' handles text while a turn is active.
-`queue' preserves Claude/vterm semantics by starting a new turn after the
-current one completes.  `steer' injects the text into the active turn via
-App Server's turn/steer method.  Calls to `magnus-codex-steer' always steer
-regardless of this setting."
-  :type '(choice (const :tag "Queue for the next turn" queue)
-                 (const :tag "Steer the active turn" steer))
+(defcustom magnus-codex-remote "unix://"
+  "Remote endpoint passed to the Codex TUI.
+The default selects the managed App Server daemon's standard Unix socket."
+  :type 'string
   :group 'magnus)
 
 (defvar magnus-codex-event-hook nil
@@ -64,156 +66,46 @@ Functions receive INSTANCE, REQUEST-ID, METHOD, and PARAMS.  Use
 `magnus-codex-respond-approval' to answer the request.")
 
 (defvar magnus-codex--connections (make-hash-table :test #'equal)
-  "Instance ID to App Server process map.")
+  "Instance ID to App Server observer proxy map.")
 
 (defvar magnus-codex--active-turns (make-hash-table :test #'equal)
   "Instance ID to active Codex turn ID map.")
 
+(defvar magnus-codex--show-on-ready (make-hash-table :test #'equal)
+  "Instance IDs whose TUI should be displayed after asynchronous startup.")
+
+(defvar magnus-codex--new-thread-owner nil
+  "Instance ID currently waiting for its TUI-created thread ID.")
+
+(defvar magnus-codex--new-thread-queue nil
+  "FIFO of (PROCESS INSTANCE INITIAL-MESSAGE) waiting to create TUI threads.")
+
 (defvar-local magnus-codex--instance nil
-  "Codex instance represented by the current output buffer.")
+  "Magnus instance represented by the current Codex TUI buffer.")
 
-(defvar-local magnus-codex--prompt-marker nil
-  "Marker at the beginning of the inline Codex prompt.")
-
-(defvar-local magnus-codex--input-marker nil
-  "Marker at the beginning of editable inline Codex input.")
-
-(defun magnus-codex-enable-inline-input ()
-  "Protect the current transcript and add an editable inline prompt."
-  (interactive)
-  (let ((inhibit-read-only t))
-    (setq buffer-read-only nil)
-    (unless (and (markerp magnus-codex--prompt-marker)
-                 (marker-position magnus-codex--prompt-marker)
-                 (markerp magnus-codex--input-marker)
-                 (marker-position magnus-codex--input-marker))
-      (add-text-properties
-       (point-min) (point-max)
-       '(read-only t rear-nonsticky (read-only face)))
-      (goto-char (point-max))
-      (unless (bolp)
-        (insert (propertize "\n" 'read-only t)))
-      (let ((prompt-start (point)))
-        (insert (propertize "> "
-                            'read-only t
-                            'face 'font-lock-keyword-face
-                            'front-sticky '(read-only face)
-                            'rear-nonsticky '(read-only face)))
-        (setq magnus-codex--prompt-marker
-              (copy-marker prompt-start t))
-        (setq magnus-codex--input-marker (copy-marker (point) nil))))
-    (goto-char (point-max))))
-
-(define-derived-mode magnus-codex-mode fundamental-mode "Magnus-Codex"
-  "Major mode for streamed Codex App Server output."
-  :group 'magnus
-  (setq buffer-read-only nil)
-  (setq-local truncate-lines nil)
-  (setq-local word-wrap t)
-  (magnus-codex-enable-inline-input))
-
-(let ((map magnus-codex-mode-map))
-  ;; Older builds derived this mode from `special-mode'; reset the parent so
-  ;; reloading the provider makes printable keys self-insert immediately.
-  (set-keymap-parent map nil)
-  (define-key map (kbd "C-c m") #'magnus-codex-send-message)
-  (define-key map (kbd "C-c a") #'magnus-codex-answer-approval)
-  (define-key map (kbd "RET") #'magnus-codex-submit-input)
-  (define-key map (kbd "<return>") #'magnus-codex-submit-input)
-  (define-key map (kbd "C-c C-c") #'magnus-codex-submit-input)
-  (define-key map (kbd "C-c C-k") #'magnus-codex-interrupt-current)
-  (define-key map (kbd "DEL") #'magnus-codex-backward-delete)
-  (define-key map (kbd "<backspace>") #'magnus-codex-backward-delete)
-  (define-key map (kbd "C-a") #'magnus-codex-beginning-of-input)
-  (define-key map [remap self-insert-command] #'magnus-codex-self-insert)
-  (define-key map [remap yank] #'magnus-codex-yank))
-
-(defun magnus-codex--buffer (instance)
-  "Create or return the output buffer for INSTANCE."
-  (let ((buffer (magnus-instance-buffer instance)))
-    (if (buffer-live-p buffer)
-        buffer
-      (setq buffer (get-buffer-create
-                    (format "*codex:%s*" (magnus-instance-name instance))))
-      (with-current-buffer buffer
-        (magnus-codex-mode)
-        (setq-local magnus-codex--instance instance)
-        (let ((inhibit-read-only t))
-          (erase-buffer)
-          (when (markerp magnus-codex--prompt-marker)
-            (set-marker magnus-codex--prompt-marker nil))
-          (when (markerp magnus-codex--input-marker)
-            (set-marker magnus-codex--input-marker nil))
-          (setq magnus-codex--prompt-marker nil
-                magnus-codex--input-marker nil)
-          (insert (format "Codex agent: %s\nDirectory: %s\n\n"
-                          (magnus-instance-name instance)
-                          (magnus-instance-directory instance))))
-        (magnus-codex-enable-inline-input))
-      (magnus-instances-update instance :buffer buffer)
-      buffer)))
+(defun magnus-codex--observer-buffer (instance)
+  "Return INSTANCE's hidden semantic observer log buffer."
+  (get-buffer-create
+   (format " *magnus-codex-observer:%s*" (magnus-instance-name instance))))
 
 (defun magnus-codex--insert (instance text &optional face)
-  "Append TEXT to INSTANCE's output buffer, optionally using FACE."
-  (let ((buffer (magnus-codex--buffer instance)))
-    (when (buffer-live-p buffer)
-      (with-current-buffer buffer
-        (unless (and (markerp magnus-codex--prompt-marker)
-                     (marker-position magnus-codex--prompt-marker))
-          (magnus-codex-enable-inline-input))
-        (let ((inhibit-read-only t)
-              (moving (= (point) (point-max))))
-          (goto-char magnus-codex--prompt-marker)
-          (let ((start (point)))
-            (insert text)
-            (add-text-properties
-             start (point)
-             (append '(read-only t rear-nonsticky (read-only face))
-                     (when face (list 'face face)))))
-          (when moving (goto-char (point-max))))))))
+  "Append TEXT to INSTANCE's hidden observer log, optionally using FACE.
+Observer events must never be inserted into the live TUI buffer: doing so
+would corrupt terminal rendering and violate the single-writer boundary."
+  (with-current-buffer (magnus-codex--observer-buffer instance)
+    (let ((inhibit-read-only t)
+          (start (point-max)))
+      (goto-char start)
+      (insert text)
+      (when face
+        (add-text-properties start (point) (list 'face face))))))
 
-(defun magnus-codex-self-insert (count)
-  "Insert the typed character COUNT times in the inline input field."
-  (interactive "p")
-  (magnus-codex-enable-inline-input)
-  (goto-char (point-max))
-  (self-insert-command count))
-
-(defun magnus-codex-yank ()
-  "Yank at the end of the inline input field."
-  (interactive)
-  (magnus-codex-enable-inline-input)
-  (goto-char (point-max))
-  (call-interactively #'yank))
-
-(defun magnus-codex-beginning-of-input ()
-  "Move to the beginning of the editable inline input field."
-  (interactive)
-  (magnus-codex-enable-inline-input)
-  (goto-char magnus-codex--input-marker))
-
-(defun magnus-codex-backward-delete (count)
-  "Delete COUNT characters backward within the inline input field."
-  (interactive "p")
-  (magnus-codex-enable-inline-input)
-  (goto-char (point-max))
-  (let ((available (- (point) magnus-codex--input-marker)))
-    (when (> available 0)
-      (delete-region (- (point) (min count available)) (point)))))
-
-(defun magnus-codex-submit-input ()
-  "Submit editable inline input to the current Codex instance."
-  (interactive)
-  (unless magnus-codex--instance
-    (user-error "This is not a Magnus Codex buffer"))
-  (magnus-codex-enable-inline-input)
-  (let ((text (string-trim
-               (buffer-substring-no-properties
-                magnus-codex--input-marker (point-max)))))
-    (unless (string-empty-p text)
-      (let ((inhibit-read-only t))
-        (delete-region magnus-codex--input-marker (point-max)))
-      (magnus-codex-send magnus-codex--instance text))))
+(defun magnus-codex--tui-process (instance)
+  "Return INSTANCE's live vterm process, or nil."
+  (when-let ((buffer (magnus-instance-buffer instance)))
+    (and (buffer-live-p buffer)
+         (let ((process (get-buffer-process buffer)))
+           (and (process-live-p process) process)))))
 
 (defun magnus-codex--connection (instance)
   "Return the live App Server process for INSTANCE, or nil."
@@ -232,11 +124,54 @@ Functions receive INSTANCE, REQUEST-ID, METHOD, and PARAMS.  Use
   "Serialize OBJECT as compact JSON."
   (json-serialize object :null-object nil :false-object :json-false))
 
+(defun magnus-codex--byte-string (&rest bytes)
+  "Return a unibyte string containing BYTES."
+  (apply #'unibyte-string bytes))
+
+(defun magnus-codex--integer-bytes (value count)
+  "Encode non-negative integer VALUE as COUNT network-order bytes."
+  (apply #'magnus-codex--byte-string
+         (cl-loop for shift from (* 8 (1- count)) downto 0 by 8
+                  collect (logand 255 (ash value (- shift))))))
+
+(defun magnus-codex--websocket-frame (text &optional opcode)
+  "Encode TEXT as a masked client WebSocket frame with OPCODE.
+OPCODE defaults to 1, the text-frame opcode."
+  (let* ((payload (if (multibyte-string-p text)
+                      (encode-coding-string text 'utf-8 t)
+                    (copy-sequence text)))
+         (length (length payload))
+         (mask (magnus-codex--byte-string
+                (random 256) (random 256) (random 256) (random 256)))
+         (header
+          (cond
+           ((< length 126)
+            (magnus-codex--byte-string
+             (logior 128 (or opcode 1)) (logior 128 length)))
+           ((< length 65536)
+            (concat (magnus-codex--byte-string
+                     (logior 128 (or opcode 1)) 254)
+                    (magnus-codex--integer-bytes length 2)))
+           (t
+            (concat (magnus-codex--byte-string
+                     (logior 128 (or opcode 1)) 255)
+                    (magnus-codex--integer-bytes length 8))))))
+    (dotimes (index length)
+      (aset payload index
+            (logxor (aref payload index) (aref mask (% index 4)))))
+    (concat header mask payload)))
+
+(defun magnus-codex--send-frame (process text &optional opcode)
+  "Send TEXT to PROCESS as a client WebSocket frame with OPCODE."
+  (process-send-string process (magnus-codex--websocket-frame text opcode)))
+
 (defun magnus-codex--send-object (process object)
-  "Send JSON-RPC OBJECT followed by a newline to PROCESS."
+  "Send JSON-RPC OBJECT as one WebSocket text frame through PROCESS."
   (unless (process-live-p process)
     (user-error "Codex App Server is not running"))
-  (process-send-string process (concat (magnus-codex--json object) "\n")))
+  (unless (process-get process 'magnus-codex-websocket-ready)
+    (user-error "Codex App Server observer is not ready"))
+  (magnus-codex--send-frame process (magnus-codex--json object)))
 
 (defun magnus-codex--request (process method params callback)
   "Send METHOD request with PARAMS through PROCESS and register CALLBACK.
@@ -261,25 +196,159 @@ CALLBACK receives RESULT and ERROR, exactly one of which is non-nil."
   (json-parse-string line :object-type 'alist :array-type 'list
                      :null-object nil :false-object :json-false))
 
+(defun magnus-codex--websocket-handshake (process)
+  "Begin the HTTP Upgrade handshake through observer proxy PROCESS."
+  (let ((key (base64-encode-string
+              (apply #'magnus-codex--byte-string
+                     (cl-loop repeat 16 collect (random 256)))
+              t)))
+    (process-put process 'magnus-codex-websocket-key key)
+    (process-send-string
+     process
+     (encode-coding-string
+      (concat "GET / HTTP/1.1\r\n"
+              "Host: localhost\r\n"
+              "Upgrade: websocket\r\n"
+              "Connection: Upgrade\r\n"
+              "Sec-WebSocket-Key: " key "\r\n"
+              "Sec-WebSocket-Version: 13\r\n\r\n")
+      'utf-8 t))))
+
+(defun magnus-codex--websocket-accept (process)
+  "Return the expected WebSocket accept value for PROCESS's handshake."
+  (base64-encode-string
+   (secure-hash
+    'sha1
+    (concat (process-get process 'magnus-codex-websocket-key)
+            "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+    nil nil t)
+   t))
+
 (defun magnus-codex--filter (process output)
-  "Consume newline-delimited JSON-RPC OUTPUT from PROCESS."
-  (let* ((partial (concat (or (process-get process 'magnus-codex-partial) "")
-                          output))
-         (lines (split-string partial "\n"))
-         (complete (butlast lines))
-         (remainder (car (last lines))))
-    (process-put process 'magnus-codex-partial remainder)
-    (dolist (line complete)
-      (unless (string-empty-p line)
-        (condition-case err
-            (magnus-codex--dispatch-message
-             process (magnus-codex--parse-line line))
-          (error
-           (when-let ((instance (process-get process 'magnus-codex-instance)))
-             (magnus-codex--insert
-              instance
-              (format "\n[protocol error] %s\n" (error-message-string err))
-              'error))))))))
+  "Safely consume App Server OUTPUT from observer PROCESS."
+  (condition-case err
+      (magnus-codex--filter-output process output)
+    (error
+     (when-let ((instance (process-get process 'magnus-codex-instance)))
+       (magnus-codex--insert
+        instance
+        (format "\n[observer protocol failure] %s\n"
+                (error-message-string err))
+        'error))
+     (when (process-live-p process)
+       (delete-process process)))))
+
+(defun magnus-codex--filter-output (process output)
+  "Consume WebSocket handshake and framed App Server OUTPUT from PROCESS."
+  (if (process-get process 'magnus-codex-websocket-ready)
+      (magnus-codex--consume-frames process output)
+    (let* ((partial (concat
+                     (or (process-get process 'magnus-codex-handshake-buffer)
+                         (magnus-codex--byte-string))
+                     output))
+           (end (string-match "\r\n\r\n" partial)))
+      (if (not end)
+          (process-put process 'magnus-codex-handshake-buffer partial)
+        (let ((headers (decode-coding-string
+                        (substring partial 0 (+ end 4)) 'utf-8 t))
+              (remainder (substring partial (+ end 4))))
+          (let ((case-fold-search t))
+            (unless (string-match-p "\\`HTTP/1\\.[01] 101\\b" headers)
+              (error "Codex App Server WebSocket upgrade failed: %s"
+                     (string-trim headers)))
+            (unless (and
+                     (string-match
+                      "^Sec-WebSocket-Accept:[ \t]*\\([^\r\n]+\\)" headers)
+                     (equal (string-trim (match-string 1 headers))
+                            (magnus-codex--websocket-accept process)))
+              (error "Codex App Server returned an invalid WebSocket accept")))
+          (process-put process 'magnus-codex-handshake-buffer nil)
+          (process-put process 'magnus-codex-websocket-ready t)
+          (when-let ((callback (process-get process 'magnus-codex-on-open)))
+            (process-put process 'magnus-codex-on-open nil)
+            (funcall callback))
+          (unless (string-empty-p remainder)
+            (magnus-codex--consume-frames process remainder)))))))
+
+(defun magnus-codex--read-integer (data start count)
+  "Read COUNT network-order bytes from DATA beginning at START."
+  (cl-loop with value = 0
+           for index from start below (+ start count)
+           do (setq value (+ (ash value 8) (aref data index)))
+           finally return value))
+
+(defun magnus-codex--consume-frames (process output)
+  "Consume zero or more WebSocket frames from PROCESS OUTPUT."
+  (let ((data (concat (or (process-get process 'magnus-codex-frame-buffer)
+                          (magnus-codex--byte-string))
+                      output))
+        (continue t))
+    (while continue
+      (if (< (length data) 2)
+          (setq continue nil)
+        (let* ((first (aref data 0))
+               (second (aref data 1))
+               (fin (not (zerop (logand first 128))))
+               (opcode (logand first 15))
+               (masked (not (zerop (logand second 128))))
+               (short-length (logand second 127))
+               (length-bytes (cond ((= short-length 126) 2)
+                                   ((= short-length 127) 8)
+                                   (t 0)))
+               (base (+ 2 length-bytes))
+               (mask-length (if masked 4 0)))
+          (if (< (length data) (+ base mask-length))
+              (setq continue nil)
+            (let ((payload-length
+                   (if (zerop length-bytes)
+                       short-length
+                     (magnus-codex--read-integer data 2 length-bytes))))
+              (when (> payload-length (* 16 1024 1024))
+                (error "Codex observer frame exceeds 16 MiB"))
+              (let* ((payload-start (+ base mask-length))
+                     (frame-end (+ payload-start payload-length)))
+                (if (> frame-end (length data))
+                    (setq continue nil)
+                  (let ((payload (copy-sequence
+                                  (substring data payload-start frame-end))))
+                    (when masked
+                      (let ((mask (substring data base (+ base 4))))
+                        (dotimes (index payload-length)
+                          (aset payload index
+                                (logxor (aref payload index)
+                                        (aref mask (% index 4)))))))
+                    (setq data (substring data frame-end))
+                    (magnus-codex--handle-frame
+                     process fin opcode payload)))))))))
+    (process-put process 'magnus-codex-frame-buffer data)))
+
+(defun magnus-codex--handle-frame (process fin opcode payload)
+  "Handle one WebSocket frame from PROCESS with FIN, OPCODE, and PAYLOAD."
+  (pcase opcode
+    (8
+     (process-put process 'magnus-codex-intentional-stop t)
+     (delete-process process))
+    (9 (magnus-codex--send-frame process payload 10))
+    (10 nil)
+    ((or 0 1)
+     (let ((fragments (append (process-get process 'magnus-codex-fragments)
+                              (list payload))))
+       (if (not fin)
+           (process-put process 'magnus-codex-fragments fragments)
+         (process-put process 'magnus-codex-fragments nil)
+         (condition-case err
+             (magnus-codex--dispatch-message
+              process
+              (magnus-codex--parse-line
+               (decode-coding-string (apply #'concat fragments) 'utf-8 t)))
+           (error
+            (when-let ((instance
+                        (process-get process 'magnus-codex-instance)))
+              (magnus-codex--insert
+               instance
+               (format "\n[protocol error] %s\n" (error-message-string err))
+               'error)))))))
+    (_ nil)))
 
 (defun magnus-codex--dispatch-message (process message)
   "Dispatch parsed JSON-RPC MESSAGE received from PROCESS."
@@ -389,6 +458,18 @@ permission-profile request instead requires its complete response alist."
     (pcase method
       ("item/agentMessage/delta"
        (magnus-codex--insert instance (or (alist-get 'delta params) "")))
+      ("thread/started"
+       (when (and (process-get process 'magnus-codex-awaiting-tui-thread)
+                  (equal magnus-codex--new-thread-owner
+                         (magnus-instance-id instance)))
+         (when-let ((thread-id
+                     (alist-get 'id (alist-get 'thread params))))
+           (process-put process 'magnus-codex-awaiting-tui-thread nil)
+           (magnus-instances-update instance :session-id thread-id)
+           (magnus-codex--insert
+            instance (format "[TUI thread started: %s]\n" thread-id)
+            'font-lock-comment-face)
+           (magnus-codex--release-new-thread-owner instance))))
       ("turn/plan/updated"
        (magnus-codex--insert instance
                              (magnus-codex--format-plan params)
@@ -405,8 +486,7 @@ permission-profile request instead requires its complete response alist."
        (remhash (magnus-instance-id instance) magnus-codex--active-turns)
        (process-put process 'magnus-codex-turn-starting nil)
        (magnus-codex--insert instance "\n[turn completed]\n\n"
-                             'font-lock-comment-face)
-       (magnus-codex--start-next-queued-turn process instance))
+                             'font-lock-comment-face))
       ("thread/status/changed"
        (magnus-codex--insert
         instance (format "\n[status: %s]\n"
@@ -440,16 +520,27 @@ permission-profile request instead requires its complete response alist."
    "\n"))
 
 (defun magnus-codex--sentinel (process event)
-  "Handle PROCESS termination EVENT."
+  "Handle observer PROCESS termination EVENT."
   (unless (process-live-p process)
     (when-let ((instance (process-get process 'magnus-codex-instance)))
-      (remhash (magnus-instance-id instance) magnus-codex--connections)
+      (when (process-get process 'magnus-codex-awaiting-tui-thread)
+        (process-put process 'magnus-codex-awaiting-tui-thread nil)
+        (when-let ((terminal (magnus-codex--tui-process instance)))
+          (set-process-query-on-exit-flag terminal nil)
+          (kill-process terminal))
+        (magnus-codex--release-new-thread-owner instance))
+      (when (eq process (gethash (magnus-instance-id instance)
+                                 magnus-codex--connections))
+        (remhash (magnus-instance-id instance) magnus-codex--connections))
       (remhash (magnus-instance-id instance) magnus-codex--active-turns)
       (magnus-codex--clear-approvals instance process)
-      (unless (eq (magnus-instance-status instance) 'purged)
+      ;; Once the TUI owns the thread, observer failure must not terminate or
+      ;; misreport the interactive session.  Before that handoff it is fatal.
+      (unless (or (magnus-codex--tui-process instance)
+                  (eq (magnus-instance-status instance) 'purged))
         (magnus-instances-update instance :status 'stopped))
       (unless (process-get process 'magnus-codex-intentional-stop)
-        (magnus-codex--insert instance (format "\n[App Server %s]" event)
+        (magnus-codex--insert instance (format "\n[observer %s]" event)
                               'font-lock-comment-face))
       (when (and (boundp 'magnus-buffer-name)
                  (get-buffer magnus-buffer-name))
@@ -463,17 +554,28 @@ permission-profile request instead requires its complete response alist."
                            magnus-codex--connections))))
     (clrhash (magnus-codex--approval-table connection))))
 
+(defun magnus-codex--ensure-daemon ()
+  "Ensure the managed local Codex App Server daemon is running."
+  (unless (executable-find magnus-codex-executable)
+    (user-error "Cannot find Codex executable: %s" magnus-codex-executable))
+  (with-temp-buffer
+    (let ((status (process-file magnus-codex-executable nil t nil
+                                "app-server" "daemon" "start")))
+      (unless (and (integerp status) (zerop status))
+        (user-error "Could not start Codex App Server daemon: %s"
+                    (string-trim (buffer-string)))))))
+
 (defun magnus-codex--start-process (instance)
-  "Start a Codex App Server process for INSTANCE."
+  "Start INSTANCE's semantic observer proxy to the managed daemon."
   (let* ((name (format "magnus-codex-%s" (magnus-instance-id instance)))
          (stderr (get-buffer-create (format " *%s-stderr*" name)))
          (default-directory (magnus-instance-directory instance))
          (process (make-process
                    :name name
                    :command (list magnus-codex-executable
-                                  "app-server" "--stdio")
+                                  "app-server" "proxy")
                    :connection-type 'pipe
-                   :coding 'utf-8-unix
+                   :coding 'binary
                    :noquery t
                    :buffer nil
                    :stderr stderr
@@ -484,44 +586,99 @@ permission-profile request instead requires its complete response alist."
     (process-put process 'magnus-codex-approvals
                  (make-hash-table :test #'equal))
     (process-put process 'magnus-codex-next-id 0)
-    (process-put process 'magnus-codex-partial "")
+    (process-put process 'magnus-codex-handshake-buffer
+                 (magnus-codex--byte-string))
+    (process-put process 'magnus-codex-frame-buffer
+                 (magnus-codex--byte-string))
+    (process-put process 'magnus-codex-websocket-ready nil)
     (process-put process 'magnus-codex-input-queue nil)
     (process-put process 'magnus-codex-turn-starting nil)
     (puthash (magnus-instance-id instance) process magnus-codex--connections)
     process))
 
 (defun magnus-codex-start (instance &optional initial-message)
-  "Start or resume Codex INSTANCE, then optionally send INITIAL-MESSAGE."
+  "Start or resume Codex INSTANCE in a TUI.
+INITIAL-MESSAGE, when non-nil, is submitted by the TUI as its first prompt."
   (when (magnus-codex--connection instance)
     (user-error "Codex instance `%s' is already running"
                 (magnus-instance-name instance)))
-  (magnus-codex--buffer instance)
+  (magnus-codex--ensure-daemon)
   (let ((process (magnus-codex--start-process instance)))
-    (magnus-codex--request
-     process "initialize"
-     '((clientInfo . ((name . "magnus") (title . "Magnus")
-                      (version . "0.1.0")))
-       (capabilities . ((experimentalApi . :json-false))))
-     (lambda (_result error)
-       (if error
-           (progn
-             (magnus-codex--insert instance
-                                   (format "[initialize failed] %s\n" error)
-                                   'error)
-             (delete-process process))
-         (magnus-codex--notify process "initialized")
-         (magnus-codex--open-thread process instance initial-message))))
+    (process-put process 'magnus-codex-on-open
+                 (lambda ()
+                   (magnus-codex--initialize
+                    process instance initial-message)))
+    (magnus-codex--websocket-handshake process)
     process))
 
+(defun magnus-codex--initialize (process instance initial-message)
+  "Initialize observer PROCESS, then open INSTANCE with INITIAL-MESSAGE."
+  (magnus-codex--request
+   process "initialize"
+   '((clientInfo . ((name . "magnus") (title . "Magnus")
+                    (version . "0.1.0")))
+     (capabilities . ((experimentalApi . :json-false))))
+   (lambda (_result error)
+     (if error
+         (progn
+           (magnus-codex--insert instance
+                                 (format "[initialize failed] %s\n" error)
+                                 'error)
+           (delete-process process))
+       (magnus-codex--notify process "initialized")
+       (if (magnus-instance-session-id instance)
+           (magnus-codex--open-thread process instance initial-message)
+         (magnus-codex--start-new-thread
+          process instance initial-message))))))
+
+(defun magnus-codex--start-new-thread (process instance initial-message)
+  "Launch a new TUI-owned thread, serializing its identity handoff."
+  (if magnus-codex--new-thread-owner
+      (setq magnus-codex--new-thread-queue
+            (append magnus-codex--new-thread-queue
+                    (list (list process instance initial-message))))
+    (setq magnus-codex--new-thread-owner (magnus-instance-id instance))
+    (process-put process 'magnus-codex-awaiting-tui-thread t)
+    (magnus-codex--spawn-tui
+     instance (magnus-codex--onboarding-prompt instance initial-message))))
+
+(defun magnus-codex--onboarding-prompt (instance &optional initial-message)
+  "Return durable first-turn onboarding for INSTANCE and INITIAL-MESSAGE.
+Remote TUI-created threads do not reliably honor CLI developer-instruction
+overrides, so the den contract is made visible and persistent in history."
+  (concat
+   (magnus-codex--instructions instance)
+   (if initial-message
+       (concat "\n\nInitial task from the user:\n" initial-message)
+     (concat "\n\nNo separate task was supplied. Complete your orientation, "
+             "report that you are ready, and then wait for the user."))))
+
+(defun magnus-codex--release-new-thread-owner (instance)
+  "Release INSTANCE's new-thread handoff lock and start the next TUI."
+  (when (equal magnus-codex--new-thread-owner
+               (magnus-instance-id instance))
+    (setq magnus-codex--new-thread-owner nil)
+    (magnus-codex--start-next-new-thread)))
+
+(defun magnus-codex--start-next-new-thread ()
+  "Start the next valid queued new Codex TUI, if any."
+  (let (entry)
+    (while (and magnus-codex--new-thread-queue (not entry))
+      (let ((candidate (pop magnus-codex--new-thread-queue)))
+        (when (and (process-live-p (car candidate))
+                   (not (eq (magnus-instance-status (cadr candidate))
+                            'purged)))
+          (setq entry candidate))))
+    (when entry
+      (apply #'magnus-codex--start-new-thread entry))))
+
 (defun magnus-codex--open-thread (process instance initial-message)
-  "Start or resume INSTANCE thread on PROCESS, then send INITIAL-MESSAGE."
+  "Resume INSTANCE on observer PROCESS, then launch its TUI."
   (let* ((thread-id (magnus-instance-session-id instance))
-         (method (if thread-id "thread/resume" "thread/start"))
-         (common `((cwd . ,(magnus-instance-directory instance))
-                   (developerInstructions . ,(magnus-codex--instructions instance))))
-         (params (if thread-id
-                     (cons `(threadId . ,thread-id) common)
-                   common)))
+         (method "thread/resume")
+         (params `((threadId . ,thread-id)
+                   (cwd . ,(magnus-instance-directory instance))
+                   (developerInstructions . ,(magnus-codex--instructions instance)))))
     (magnus-codex--request
      process method params
      (lambda (result error)
@@ -530,19 +687,97 @@ permission-profile request instead requires its complete response alist."
              (magnus-codex--insert instance
                                    (format "[%s failed] %s\n" method error)
                                    'error)
-             (magnus-instances-update instance :status 'stopped)
-             (delete-process process))
+             ;; A brand-new TUI session has no rollout until its first turn.
+             ;; If it was archived before then, nothing can be lost: clear the
+             ;; unusable ID and let the TUI create a fresh persisted identity.
+             (magnus-instances-update instance :session-id nil)
+             (magnus-codex--start-new-thread
+              process instance initial-message))
          (let ((new-id (alist-get 'id (alist-get 'thread result))))
            (when new-id
              (magnus-instances-update instance :session-id new-id))
-           (magnus-instances-update instance :status 'running)
            (magnus-codex--insert instance
                                  (format "[thread %s: %s]\n\n"
                                          (if thread-id "resumed" "started")
                                          (or new-id thread-id))
                                  'font-lock-comment-face)
-           (when initial-message
-             (magnus-codex-send instance initial-message))))))))
+           (magnus-codex--spawn-tui instance initial-message)))))))
+
+(defun magnus-codex--tui-command (instance &optional initial-message)
+  "Return the shell command used to run INSTANCE's new or resumed TUI.
+INITIAL-MESSAGE becomes the optional initial prompt."
+  (let ((thread-id (magnus-instance-session-id instance)))
+    (mapconcat
+     #'shell-quote-argument
+     (append (list "exec" magnus-codex-executable)
+             (when thread-id (list "resume"))
+             (list "--remote" magnus-codex-remote
+                   "-C" (magnus-instance-directory instance))
+             (when thread-id (list thread-id))
+             (when initial-message (list initial-message)))
+     " ")))
+
+(defun magnus-codex--spawn-tui (instance &optional initial-message)
+  "Launch INSTANCE's full Codex TUI, optionally with INITIAL-MESSAGE."
+  (let* ((buffer-name (format "*codex:%s*" (magnus-instance-name instance)))
+         (default-directory (magnus-instance-directory instance))
+         (buffer (magnus-process--create-vterm-buffer buffer-name))
+         (command (magnus-codex--tui-command instance initial-message)))
+    (with-current-buffer buffer
+      (setq-local magnus-codex--instance instance))
+    ;; A freshly created vterm may still be initializing its login shell.  Give
+    ;; it one tick before pasting, then another before submitting the command.
+    (run-with-timer
+     0.1 nil
+     (lambda ()
+       (when (buffer-live-p buffer)
+         (with-current-buffer buffer
+           (vterm-send-string command)))))
+    (run-with-timer
+     0.5 nil
+     (lambda ()
+       (when (buffer-live-p buffer)
+         (with-current-buffer buffer
+           (vterm-send-return)))))
+    (magnus-instances-update instance :buffer buffer :status 'running)
+    (magnus-codex--setup-tui-sentinel instance buffer)
+    (when (gethash (magnus-instance-id instance) magnus-codex--show-on-ready)
+      (remhash (magnus-instance-id instance) magnus-codex--show-on-ready)
+      (pop-to-buffer buffer))
+    (when (and (boundp 'magnus-buffer-name)
+               (get-buffer magnus-buffer-name))
+      (magnus-status-refresh))
+    buffer))
+
+(defun magnus-codex--setup-tui-sentinel (instance buffer)
+  "Track the interactive Codex process for INSTANCE in BUFFER."
+  (when-let ((process (get-buffer-process buffer)))
+    (process-put process 'magnus-codex-observer
+                 (magnus-codex--connection instance))
+    (set-process-sentinel
+     process
+     (lambda (terminal _event)
+       (unless (process-live-p terminal)
+         (when-let ((observer
+                     (process-get terminal 'magnus-codex-observer)))
+           (process-put observer 'magnus-codex-intentional-stop t)
+           (when (process-live-p observer)
+             (delete-process observer)))
+         ;; A stale vterm can report its exit after a replacement TUI exists.
+         ;; Only the terminal still owned by INSTANCE may release or stop it.
+         (when (and (buffer-live-p (magnus-instance-buffer instance))
+                    (eq terminal
+                        (get-buffer-process
+                         (magnus-instance-buffer instance))))
+           (when (and (null (magnus-instance-session-id instance))
+                      (equal magnus-codex--new-thread-owner
+                             (magnus-instance-id instance)))
+             (magnus-codex--release-new-thread-owner instance))
+           (unless (eq (magnus-instance-status instance) 'purged)
+             (magnus-instances-update instance :status 'stopped))
+           (when (and (boundp 'magnus-buffer-name)
+                      (get-buffer magnus-buffer-name))
+             (magnus-status-refresh))))))))
 
 (defun magnus-codex--instructions (instance)
   "Build Magnus identity and coordination instructions for Codex INSTANCE."
@@ -615,153 +850,76 @@ permission-profile request instead requires its complete response alist."
   "Build App Server user input for TEXT."
   `[((type . "text") (text . ,text))])
 
-(defun magnus-codex--queue-input (process text)
-  "Append TEXT to PROCESS's next-turn input queue."
-  (process-put process 'magnus-codex-input-queue
-               (append (process-get process 'magnus-codex-input-queue)
-                       (list text))))
-
-(defun magnus-codex--start-next-queued-turn (process instance)
-  "Start INSTANCE's next queued turn through PROCESS when idle."
-  (unless (or (gethash (magnus-instance-id instance)
-                       magnus-codex--active-turns)
-              (process-get process 'magnus-codex-turn-starting))
-    (when-let ((queue (process-get process 'magnus-codex-input-queue)))
-      (let ((text (car queue))
-            (thread-id (magnus-instance-session-id instance)))
-        (unless thread-id
-          (user-error "Codex thread is not ready yet"))
-        (process-put process 'magnus-codex-input-queue (cdr queue))
-        (process-put process 'magnus-codex-turn-starting t)
-        (magnus-codex--insert instance (format "\nYou: %s\n\n" text)
-                              'font-lock-keyword-face)
-        (magnus-codex--request
-         process "turn/start"
-         `((threadId . ,thread-id) (input . ,(magnus-codex--input text)))
-         (lambda (result error)
-           (process-put process 'magnus-codex-turn-starting nil)
-           (if error
-               (progn
-                 (process-put
-                  process 'magnus-codex-input-queue
-                  (cons text (process-get process
-                                          'magnus-codex-input-queue)))
-                 (magnus-codex--insert
-                  instance
-                  (format "[turn/start failed; message retained] %s\n" error)
-                  'error))
-             (when-let ((turn-id
-                         (magnus-codex--turn-id (alist-get 'turn result))))
-               (puthash (magnus-instance-id instance) turn-id
-                        magnus-codex--active-turns)))))))))
-
 (defun magnus-codex-send (instance text)
-  "Send TEXT to Codex INSTANCE according to the active-turn delivery policy.
-By default, text received during an active turn is queued for a new turn so
-coordination nudges match Claude/vterm behavior.  See
-`magnus-codex-active-turn-delivery' and `magnus-codex-steer'."
-  (let* ((process (or (magnus-codex--connection instance)
-                      (user-error "Codex instance is not running")))
-         (_thread-id (or (magnus-instance-session-id instance)
-                         (user-error "Codex thread is not ready yet")))
-         (turn-id (gethash (magnus-instance-id instance)
-                           magnus-codex--active-turns)))
-    (if (and turn-id (eq magnus-codex-active-turn-delivery 'steer))
-        (magnus-codex-steer instance text turn-id)
-      (magnus-codex--queue-input process text)
-      (if (or turn-id (process-get process 'magnus-codex-turn-starting))
-          (magnus-codex--insert instance
-                                "\n[message queued for next turn]\n"
-                                'font-lock-comment-face)
-        (magnus-codex--start-next-queued-turn process instance)))))
+  "Submit TEXT through INSTANCE's Codex TUI.
+The semantic observer never starts or steers turns; this keeps the TUI as the
+only interactive writer and lets Codex apply its native input semantics."
+  (let ((buffer (magnus-instance-buffer instance)))
+    (unless (and (buffer-live-p buffer) (magnus-codex--tui-process instance))
+      (user-error "Codex instance `%s' is not running"
+                  (magnus-instance-name instance)))
+    (with-current-buffer buffer
+      (vterm-send-string text))
+    (run-with-timer
+     0.1 nil
+     (lambda ()
+       (when (and (buffer-live-p buffer)
+                  (process-live-p (get-buffer-process buffer)))
+         (with-current-buffer buffer
+           (vterm-send-return)))))))
 
-(defun magnus-codex-steer (instance text &optional expected-turn-id)
-  "Steer active Codex INSTANCE turn with TEXT.
-EXPECTED-TURN-ID defaults to INSTANCE's current active turn."
-  (let ((process (or (magnus-codex--connection instance)
-                     (user-error "Codex instance is not running")))
-        (thread-id (or (magnus-instance-session-id instance)
-                       (user-error "Codex thread is not ready yet")))
-        (turn-id (or expected-turn-id
-                     (gethash (magnus-instance-id instance)
-                              magnus-codex--active-turns)
-                     (user-error "Codex has no active turn to steer"))))
-    (magnus-codex--insert instance (format "\nYou (steer): %s\n\n" text)
-                          'font-lock-keyword-face)
-    (magnus-codex--request
-     process "turn/steer"
-     `((threadId . ,thread-id) (expectedTurnId . ,turn-id)
-       (input . ,(magnus-codex--input text)))
-     (lambda (_result error)
-       (when error
-         (magnus-codex--insert instance
-                               (format "[turn/steer failed] %s\n" error)
-                               'error))))))
+(defun magnus-codex-steer (instance text &optional _expected-turn-id)
+  "Submit TEXT through INSTANCE's TUI using Codex's native active-turn UI."
+  (magnus-codex-send instance text))
 
 (defun magnus-codex-interrupt (instance)
-  "Interrupt the active turn for Codex INSTANCE."
-  (let ((process (or (magnus-codex--connection instance)
-                     (user-error "Codex instance is not running")))
-        (thread-id (or (magnus-instance-session-id instance)
-                       (user-error "Codex thread is not ready yet")))
-        (turn-id (or (gethash (magnus-instance-id instance)
-                              magnus-codex--active-turns)
-                     (user-error "Codex has no active turn"))))
-    (magnus-codex--request
-     process "turn/interrupt"
-     `((threadId . ,thread-id) (turnId . ,turn-id))
-     (lambda (_result error)
-       (if error
-           (magnus-codex--insert instance
-                                 (format "[interrupt failed] %s\n" error)
-                                 'error)
-         (remhash (magnus-instance-id instance) magnus-codex--active-turns)
-         (magnus-codex--insert instance "[turn interrupted]\n"
-                               'font-lock-comment-face))))))
+  "Interrupt the active turn through Codex INSTANCE's TUI."
+  (let ((buffer (magnus-instance-buffer instance)))
+    (unless (and (buffer-live-p buffer) (magnus-codex--tui-process instance))
+      (user-error "Codex instance `%s' is not running"
+                  (magnus-instance-name instance)))
+    (with-current-buffer buffer
+      (vterm-send-key "C-c"))))
 
 (defun magnus-codex-stop (instance &optional force)
-  "Stop Codex INSTANCE App Server process.
-When FORCE is non-nil, kill it immediately."
+  "Stop Codex INSTANCE's TUI and observer, never the shared daemon.
+When FORCE is non-nil, kill subprocesses immediately."
   (let ((buffer (magnus-instance-buffer instance)))
-    (when-let ((process (magnus-codex--connection instance)))
-      (process-put process 'magnus-codex-intentional-stop t)
-      (if force (kill-process process) (delete-process process)))
+    (when-let ((observer (magnus-codex--connection instance)))
+      (process-put observer 'magnus-codex-intentional-stop t)
+      (if force (kill-process observer) (delete-process observer)))
     (when (buffer-live-p buffer)
+      (when-let ((terminal (get-buffer-process buffer)))
+        (set-process-query-on-exit-flag terminal nil)
+        (when (process-live-p terminal)
+          (if force (kill-process terminal) (delete-process terminal))))
       (kill-buffer buffer)))
   (remhash (magnus-instance-id instance) magnus-codex--connections)
   (remhash (magnus-instance-id instance) magnus-codex--active-turns)
+  (remhash (magnus-instance-id instance) magnus-codex--show-on-ready)
+  (setq magnus-codex--new-thread-queue
+        (cl-remove-if (lambda (entry) (eq (cadr entry) instance))
+                      magnus-codex--new-thread-queue))
+  (magnus-codex--release-new-thread-owner instance)
   (magnus-instances-update instance :status 'stopped :buffer nil))
 
 (defun magnus-codex-running-p (instance)
-  "Return non-nil if Codex INSTANCE has a live App Server connection."
-  (and (magnus-codex--connection instance) t))
+  "Return non-nil when Codex INSTANCE has a live interactive TUI."
+  (and (magnus-codex--tui-process instance) t))
 
 (defun magnus-codex-switch-to (instance)
-  "Switch to Codex INSTANCE, resuming its thread when necessary."
-  (unless (magnus-codex-running-p instance)
-    (magnus-codex-start instance))
-  (pop-to-buffer (magnus-codex--buffer instance)))
-
-(defun magnus-codex-send-message ()
-  "Prompt for and send a message from a Codex output buffer."
-  (interactive)
-  (unless magnus-codex--instance
-    (user-error "This is not a Magnus Codex buffer"))
-  (let ((text (read-string (format "Message to %s: "
-                                   (magnus-instance-name
-                                    magnus-codex--instance)))))
-    (unless (string-empty-p text)
-      (magnus-codex-send magnus-codex--instance text))))
-
-(defun magnus-codex-interrupt-current ()
-  "Interrupt the Codex instance represented by the current buffer."
-  (interactive)
-  (unless magnus-codex--instance
-    (user-error "This is not a Magnus Codex buffer"))
-  (magnus-codex-interrupt magnus-codex--instance))
+  "Switch to Codex INSTANCE, resuming its TUI when necessary."
+  (if (magnus-codex-running-p instance)
+      (pop-to-buffer (magnus-instance-buffer instance))
+    (puthash (magnus-instance-id instance) t magnus-codex--show-on-ready)
+    (unless (magnus-codex--connection instance)
+      (magnus-codex-start instance))
+    (message "Magnus: starting Codex TUI for %s..."
+             (magnus-instance-name instance))))
 
 (defun magnus-codex-answer-approval ()
-  "Answer a pending command or file approval in the current Codex buffer."
+  "Answer a fallback observer approval in the current Codex TUI.
+Normal interactive approvals are owned and rendered by the TUI itself."
   (interactive)
   (unless magnus-codex--instance
     (user-error "This is not a Magnus Codex buffer"))

--- a/magnus-provider-codex.el
+++ b/magnus-provider-codex.el
@@ -138,7 +138,7 @@ would corrupt terminal rendering and violate the single-writer boundary."
   "Encode TEXT as a masked client WebSocket frame with OPCODE.
 OPCODE defaults to 1, the text-frame opcode."
   (let* ((payload (if (multibyte-string-p text)
-                      (encode-coding-string text 'utf-8 t)
+                      (encode-coding-string text 'utf-8)
                     (copy-sequence text)))
          (length (length payload))
          (mask (magnus-codex--byte-string
@@ -212,7 +212,7 @@ CALLBACK receives RESULT and ERROR, exactly one of which is non-nil."
               "Connection: Upgrade\r\n"
               "Sec-WebSocket-Key: " key "\r\n"
               "Sec-WebSocket-Version: 13\r\n\r\n")
-      'utf-8 t))))
+      'utf-8))))
 
 (defun magnus-codex--websocket-accept (process)
   "Return the expected WebSocket accept value for PROCESS's handshake."
@@ -266,7 +266,9 @@ CALLBACK receives RESULT and ERROR, exactly one of which is non-nil."
           (process-put process 'magnus-codex-websocket-ready t)
           (when-let ((callback (process-get process 'magnus-codex-on-open)))
             (process-put process 'magnus-codex-on-open nil)
-            (funcall callback))
+            ;; Emacs 29 can leave a write to this same process buffered when it
+            ;; is issued reentrantly from the process filter.
+            (run-at-time 0 nil callback))
           (unless (string-empty-p remainder)
             (magnus-codex--consume-frames process remainder)))))))
 
@@ -558,12 +560,19 @@ permission-profile request instead requires its complete response alist."
   "Ensure the managed local Codex App Server daemon is running."
   (unless (executable-find magnus-codex-executable)
     (user-error "Cannot find Codex executable: %s" magnus-codex-executable))
-  (with-temp-buffer
-    (let ((status (process-file magnus-codex-executable nil t nil
-                                "app-server" "daemon" "start")))
-      (unless (and (integerp status) (zerop status))
-        (user-error "Could not start Codex App Server daemon: %s"
-                    (string-trim (buffer-string)))))))
+  (let ((socket (expand-file-name
+                 "app-server-control/app-server-control.sock"
+                 (or (getenv "CODEX_HOME")
+                     (expand-file-name ".codex" "~")))))
+    ;; `daemon start' can wait on its management lock when invoked from a GUI
+    ;; Emacs even though the healthy daemon socket already exists.
+    (unless (file-exists-p socket)
+      (with-temp-buffer
+        (let ((status (process-file magnus-codex-executable nil t nil
+                                    "app-server" "daemon" "start")))
+          (unless (and (integerp status) (zerop status))
+            (user-error "Could not start Codex App Server daemon: %s"
+                        (string-trim (buffer-string)))))))))
 
 (defun magnus-codex--start-process (instance)
   "Start INSTANCE's semantic observer proxy to the managed daemon."
@@ -627,7 +636,13 @@ INITIAL-MESSAGE, when non-nil, is submitted by the TUI as its first prompt."
            (delete-process process))
        (magnus-codex--notify process "initialized")
        (if (magnus-instance-session-id instance)
-           (magnus-codex--open-thread process instance initial-message)
+           (progn
+             (magnus-codex--insert
+              instance
+              (format "[handing saved thread to TUI: %s]\n"
+                      (magnus-instance-session-id instance))
+              'font-lock-comment-face)
+             (magnus-codex--spawn-tui instance initial-message))
          (magnus-codex--start-new-thread
           process instance initial-message))))))
 
@@ -671,37 +686,6 @@ overrides, so the den contract is made visible and persistent in history."
           (setq entry candidate))))
     (when entry
       (apply #'magnus-codex--start-new-thread entry))))
-
-(defun magnus-codex--open-thread (process instance initial-message)
-  "Resume INSTANCE on observer PROCESS, then launch its TUI."
-  (let* ((thread-id (magnus-instance-session-id instance))
-         (method "thread/resume")
-         (params `((threadId . ,thread-id)
-                   (cwd . ,(magnus-instance-directory instance))
-                   (developerInstructions . ,(magnus-codex--instructions instance)))))
-    (magnus-codex--request
-     process method params
-     (lambda (result error)
-       (if error
-           (progn
-             (magnus-codex--insert instance
-                                   (format "[%s failed] %s\n" method error)
-                                   'error)
-             ;; A brand-new TUI session has no rollout until its first turn.
-             ;; If it was archived before then, nothing can be lost: clear the
-             ;; unusable ID and let the TUI create a fresh persisted identity.
-             (magnus-instances-update instance :session-id nil)
-             (magnus-codex--start-new-thread
-              process instance initial-message))
-         (let ((new-id (alist-get 'id (alist-get 'thread result))))
-           (when new-id
-             (magnus-instances-update instance :session-id new-id))
-           (magnus-codex--insert instance
-                                 (format "[thread %s: %s]\n\n"
-                                         (if thread-id "resumed" "started")
-                                         (or new-id thread-id))
-                                 'font-lock-comment-face)
-           (magnus-codex--spawn-tui instance initial-message)))))))
 
 (defun magnus-codex--tui-command (instance &optional initial-message)
   "Return the shell command used to run INSTANCE's new or resumed TUI.

--- a/magnus-provider-codex.el
+++ b/magnus-provider-codex.el
@@ -1,4 +1,4 @@
-;;; magnus-provider-codex.el --- Codex App Server provider for Magnus -*- lexical-binding: t -*-
+;;; magnus-provider-codex.el --- Native Codex TUI provider for Magnus -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2026 Hrishikesh S
 ;; Author: Hrishikesh S <hrish2006@gmail.com>
@@ -8,11 +8,10 @@
 
 ;;; Commentary:
 
-;; Opt-in Codex support with a real Codex TUI in a vterm buffer.  A lightweight
-;; JSON-RPC observer connects through `codex app-server proxy' to the managed
-;; local daemon, while the TUI is the sole interactive writer for the thread.
-;; This preserves native input, approvals, rendering, and session resurrection
-;; without starting one App Server per Magnus agent.
+;; Opt-in Codex support using the native Codex TUI as the single owner of each
+;; session.  Magnus launches Codex directly in vterm, delivers coordination
+;; messages through that terminal, and discovers new session IDs from Codex's
+;; local rollout records so archived agents can be resumed later.
 
 ;;; Code:
 
@@ -31,106 +30,32 @@
 (defvar magnus-buffer-name)
 
 (defcustom magnus-codex-executable "codex"
-  "Path to the Codex executable used for App Server sessions."
+  "Path to the Codex executable used for native TUI sessions."
   :type 'string
-  :group 'magnus)
-
-(defcustom magnus-codex-approval-handler nil
-  "Optional function called for each Codex approval request.
-The function receives INSTANCE, REQUEST-ID, METHOD, and PARAMS.  It may call
-`magnus-codex-respond-approval' immediately or later.  When nil, the request
-remains pending in the hidden observer log; normal interactive approvals are
-displayed and answered by the native TUI.  Fallback observer approvals can be
-answered with `M-x magnus-codex-answer-approval'.  A delayed handler should
-capture `magnus-codex-current-approval-token' during this callback and pass it
-when responding."
-  :type '(choice (const :tag "Queue for manual handling" nil)
-                 (function :tag "Handler function"))
   :group 'magnus)
 
 (defcustom magnus-codex-extra-developer-instructions nil
-  "Optional extra developer instructions for Magnus-managed Codex threads.
-Magnus always supplies a small provider-neutral coordination preamble."
+  "Optional extra instructions for Magnus-managed Codex sessions."
   :type '(choice (const :tag "None" nil) string)
   :group 'magnus)
 
-(defcustom magnus-codex-remote "unix://"
-  "Unix-socket endpoint shared by the Codex TUI and Magnus observer.
-The default `unix://' selects the managed App Server daemon's standard socket.
-A custom local socket may be written as `unix:///absolute/path'.
-Network WebSocket endpoints are not supported by the observer."
-  :type 'string
-  :group 'magnus)
-
-(defcustom magnus-codex-startup-timeout 15
-  "Seconds before an incomplete Codex observer startup is abandoned."
-  :type 'number
-  :group 'magnus)
-
 (defcustom magnus-codex-tui-ready-delay 1.0
-  "Seconds after launching the Codex command before queued input may be sent.
-This protects the login shell command from coordination messages arriving
-during startup."
+  "Seconds after launch before queued input may be sent to Codex.
+This protects the shell command and initial prompt from coordination messages
+arriving during startup."
   :type 'number
   :group 'magnus)
 
-(defvar magnus-codex-event-hook nil
-  "Hook run after a Codex server event.
-Functions receive INSTANCE, METHOD, and PARAMS.")
+(defcustom magnus-codex-session-capture-timeout 30
+  "Seconds to wait for a new Codex TUI to record its session ID."
+  :type 'number
+  :group 'magnus)
 
-(defvar magnus-codex-approval-request-hook nil
-  "Hook run when Codex requests semantic approval.
-Functions receive INSTANCE, REQUEST-ID, METHOD, and PARAMS.  Use
-`magnus-codex-respond-approval' to answer the request.")
-
-(defvar magnus-codex-current-approval-token nil
-  "Generation token dynamically bound while approval callbacks run.
-Delayed approval handlers should retain this value and pass it to
-`magnus-codex-respond-approval'.")
-
-(defvar magnus-codex--connections (make-hash-table :test #'equal)
-  "Instance ID to App Server observer proxy map.")
-
-(defvar magnus-codex--active-turns (make-hash-table :test #'equal)
-  "Instance ID to active Codex turn ID map.")
-
-(defvar magnus-codex--show-on-ready (make-hash-table :test #'equal)
-  "Instance IDs whose TUI should be displayed after asynchronous startup.")
-
-(defvar magnus-codex--retired-approval-ids (make-hash-table :test #'equal)
-  "Instance/request IDs retired while a delayed answer may still exist.")
-
-(defvar magnus-codex--input-queues (make-hash-table :test #'equal)
-  "Instance ID to FIFO of text waiting for serialized TUI submission.")
-
-(defvar magnus-codex--input-busy (make-hash-table :test #'equal)
-  "Instance IDs with an automated TUI submission in flight.")
-
-(defvar magnus-codex--input-retry (make-hash-table :test #'equal)
-  "Instance IDs waiting for the user to leave their TUI buffer.")
-
-(defvar magnus-codex--tui-ready (make-hash-table :test #'equal)
-  "Instance IDs whose TUI launch command has been submitted.")
+(defconst magnus-codex--session-scan-limit (* 1024 1024)
+  "Maximum rollout bytes inspected while identifying a new session.")
 
 (defvar-local magnus-codex--instance nil
   "Magnus instance represented by the current Codex TUI buffer.")
-
-(defun magnus-codex--observer-buffer (instance)
-  "Return INSTANCE's hidden semantic observer log buffer."
-  (get-buffer-create
-   (format " *magnus-codex-observer:%s*" (magnus-instance-name instance))))
-
-(defun magnus-codex--insert (instance text &optional face)
-  "Append TEXT to INSTANCE's hidden observer log, optionally using FACE.
-Observer events must never be inserted into the live TUI buffer: doing so
-would corrupt terminal rendering and violate the single-writer boundary."
-  (with-current-buffer (magnus-codex--observer-buffer instance)
-    (let ((inhibit-read-only t)
-          (start (point-max)))
-      (goto-char start)
-      (insert text)
-      (when face
-        (add-text-properties start (point) (list 'face face))))))
 
 (defun magnus-codex--tui-process (instance)
   "Return INSTANCE's live vterm process, or nil."
@@ -139,805 +64,145 @@ would corrupt terminal rendering and violate the single-writer boundary."
          (let ((process (get-buffer-process buffer)))
            (and (process-live-p process) process)))))
 
-(defun magnus-codex--connection (instance)
-  "Return the live App Server process for INSTANCE, or nil."
-  (let ((process (gethash (magnus-instance-id instance)
-                          magnus-codex--connections)))
-    (and (process-live-p process) process)))
+(defun magnus-codex--current-process-p (process instance)
+  "Return non-nil when PROCESS is INSTANCE's current live terminal."
+  (eq process (magnus-codex--tui-process instance)))
 
-(defun magnus-codex--approval-table (process)
-  "Return PROCESS's private pending approval table."
-  (or (process-get process 'magnus-codex-approvals)
-      (let ((table (make-hash-table :test #'equal)))
-        (process-put process 'magnus-codex-approvals table)
-        table)))
-
-(defun magnus-codex--json (object)
-  "Serialize OBJECT as compact JSON."
-  (json-serialize object :null-object nil :false-object :json-false))
-
-(defun magnus-codex--byte-string (&rest bytes)
-  "Return a unibyte string containing BYTES."
-  (apply #'unibyte-string bytes))
-
-(defun magnus-codex--integer-bytes (value count)
-  "Encode non-negative integer VALUE as COUNT network-order bytes."
-  (apply #'magnus-codex--byte-string
-         (cl-loop for shift from (* 8 (1- count)) downto 0 by 8
-                  collect (logand 255 (ash value (- shift))))))
-
-(defun magnus-codex--websocket-frame (text &optional opcode)
-  "Encode TEXT as a masked client WebSocket frame with OPCODE.
-OPCODE defaults to 1, the text-frame opcode."
-  (let* ((payload (if (multibyte-string-p text)
-                      (encode-coding-string text 'utf-8)
-                    (copy-sequence text)))
-         (length (length payload))
-         (mask (magnus-codex--byte-string
-                (random 256) (random 256) (random 256) (random 256)))
-         (header
-          (cond
-           ((< length 126)
-            (magnus-codex--byte-string
-             (logior 128 (or opcode 1)) (logior 128 length)))
-           ((< length 65536)
-            (concat (magnus-codex--byte-string
-                     (logior 128 (or opcode 1)) 254)
-                    (magnus-codex--integer-bytes length 2)))
-           (t
-            (concat (magnus-codex--byte-string
-                     (logior 128 (or opcode 1)) 255)
-                    (magnus-codex--integer-bytes length 8))))))
-    (dotimes (index length)
-      (aset payload index
-            (logxor (aref payload index) (aref mask (% index 4)))))
-    (concat header mask payload)))
-
-(defun magnus-codex--send-frame (process text &optional opcode)
-  "Send TEXT to PROCESS as a client WebSocket frame with OPCODE."
-  (process-send-string process (magnus-codex--websocket-frame text opcode)))
-
-(defun magnus-codex--send-object (process object)
-  "Send JSON-RPC OBJECT as one WebSocket text frame through PROCESS."
-  (unless (process-live-p process)
-    (user-error "Codex App Server is not running"))
-  (unless (process-get process 'magnus-codex-websocket-ready)
-    (user-error "Codex App Server observer is not ready"))
-  (magnus-codex--send-frame process (magnus-codex--json object)))
-
-(defun magnus-codex--request (process method params callback)
-  "Send METHOD request with PARAMS through PROCESS and register CALLBACK.
-CALLBACK receives RESULT and ERROR, exactly one of which is non-nil."
-  (let* ((next (1+ (or (process-get process 'magnus-codex-next-id) 0)))
-         (pending (process-get process 'magnus-codex-pending)))
-    (process-put process 'magnus-codex-next-id next)
-    (puthash next callback pending)
-    (magnus-codex--send-object
-     process `((jsonrpc . "2.0") (id . ,next) (method . ,method)
-               (params . ,params)))
-    next))
-
-(defun magnus-codex--notify (process method &optional params)
-  "Send METHOD notification and optional PARAMS through PROCESS."
-  (magnus-codex--send-object
-   process (append `((jsonrpc . "2.0") (method . ,method))
-                   (when params `((params . ,params))))))
-
-(defun magnus-codex--parse-line (line)
-  "Parse one JSON-RPC LINE into an alist."
-  (json-parse-string line :object-type 'alist :array-type 'list
-                     :null-object nil :false-object :json-false))
-
-(defun magnus-codex--websocket-handshake (process)
-  "Begin the HTTP Upgrade handshake through observer proxy PROCESS."
-  (let ((key (base64-encode-string
-              (apply #'magnus-codex--byte-string
-                     (cl-loop repeat 16 collect (random 256)))
-              t)))
-    (process-put process 'magnus-codex-websocket-key key)
-    (process-send-string
-     process
-     (encode-coding-string
-      (concat "GET / HTTP/1.1\r\n"
-              "Host: localhost\r\n"
-              "Upgrade: websocket\r\n"
-              "Connection: Upgrade\r\n"
-              "Sec-WebSocket-Key: " key "\r\n"
-              "Sec-WebSocket-Version: 13\r\n\r\n")
-      'utf-8))))
-
-(defun magnus-codex--websocket-accept (process)
-  "Return the expected WebSocket accept value for PROCESS's handshake."
-  (base64-encode-string
-   (secure-hash
-    'sha1
-    (concat (process-get process 'magnus-codex-websocket-key)
-            "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
-    nil nil t)
-   t))
-
-(defun magnus-codex--filter (process output)
-  "Safely consume App Server OUTPUT from observer PROCESS."
-  (condition-case err
-      (magnus-codex--filter-output process output)
-    (error
-     (when-let ((instance (process-get process 'magnus-codex-instance)))
-       (magnus-codex--insert
-        instance
-        (format "\n[observer protocol failure] %s\n"
-                (error-message-string err))
-        'error))
-     (when (process-live-p process)
-       (delete-process process)))))
-
-(defun magnus-codex--filter-output (process output)
-  "Consume WebSocket handshake and framed App Server OUTPUT from PROCESS."
-  (if (process-get process 'magnus-codex-websocket-ready)
-      (magnus-codex--consume-frames process output)
-    (let* ((partial (concat
-                     (or (process-get process 'magnus-codex-handshake-buffer)
-                         (magnus-codex--byte-string))
-                     output))
-           (end (string-match "\r\n\r\n" partial)))
-      (if (not end)
-          (process-put process 'magnus-codex-handshake-buffer partial)
-        (let ((headers (decode-coding-string
-                        (substring partial 0 (+ end 4)) 'utf-8 t))
-              (remainder (substring partial (+ end 4))))
-          (let ((case-fold-search t))
-            (unless (string-match-p "\\`HTTP/1\\.[01] 101\\b" headers)
-              (error "Codex App Server WebSocket upgrade failed: %s"
-                     (string-trim headers)))
-            (unless (and
-                     (string-match
-                      "^Sec-WebSocket-Accept:[ \t]*\\([^\r\n]+\\)" headers)
-                     (equal (string-trim (match-string 1 headers))
-                            (magnus-codex--websocket-accept process)))
-              (error "Codex App Server returned an invalid WebSocket accept")))
-          (process-put process 'magnus-codex-handshake-buffer nil)
-          (process-put process 'magnus-codex-websocket-ready t)
-          (when-let ((callback (process-get process 'magnus-codex-on-open)))
-            (process-put process 'magnus-codex-on-open nil)
-            ;; Emacs 29 can leave a write to this same process buffered when it
-            ;; is issued reentrantly from the process filter.
-            (run-at-time 0 nil callback))
-          (unless (string-empty-p remainder)
-            (magnus-codex--consume-frames process remainder)))))))
-
-(defun magnus-codex--read-integer (data start count)
-  "Read COUNT network-order bytes from DATA beginning at START."
-  (cl-loop with value = 0
-           for index from start below (+ start count)
-           do (setq value (+ (ash value 8) (aref data index)))
-           finally return value))
-
-(defun magnus-codex--consume-frames (process output)
-  "Consume zero or more WebSocket frames from PROCESS OUTPUT."
-  (let ((data (concat (or (process-get process 'magnus-codex-frame-buffer)
-                          (magnus-codex--byte-string))
-                      output))
-        (continue t))
-    (while continue
-      (if (< (length data) 2)
-          (setq continue nil)
-        (let* ((first (aref data 0))
-               (second (aref data 1))
-               (fin (not (zerop (logand first 128))))
-               (opcode (logand first 15))
-               (masked (not (zerop (logand second 128))))
-               (short-length (logand second 127))
-               (length-bytes (cond ((= short-length 126) 2)
-                                   ((= short-length 127) 8)
-                                   (t 0)))
-               (base (+ 2 length-bytes))
-               (mask-length (if masked 4 0)))
-          (if (< (length data) (+ base mask-length))
-              (setq continue nil)
-            (let ((payload-length
-                   (if (zerop length-bytes)
-                       short-length
-                     (magnus-codex--read-integer data 2 length-bytes))))
-              (when (> payload-length (* 16 1024 1024))
-                (error "Codex observer frame exceeds 16 MiB"))
-              (let* ((payload-start (+ base mask-length))
-                     (frame-end (+ payload-start payload-length)))
-                (if (> frame-end (length data))
-                    (setq continue nil)
-                  (let ((payload (copy-sequence
-                                  (substring data payload-start frame-end))))
-                    (when masked
-                      (let ((mask (substring data base (+ base 4))))
-                        (dotimes (index payload-length)
-                          (aset payload index
-                                (logxor (aref payload index)
-                                        (aref mask (% index 4)))))))
-                    (setq data (substring data frame-end))
-                    (magnus-codex--handle-frame
-                     process fin opcode payload)))))))))
-    (process-put process 'magnus-codex-frame-buffer data)))
-
-(defun magnus-codex--handle-frame (process fin opcode payload)
-  "Handle one WebSocket frame from PROCESS with FIN, OPCODE, and PAYLOAD."
-  (pcase opcode
-    (8
-     (process-put process 'magnus-codex-intentional-stop t)
-     (delete-process process))
-    (9 (magnus-codex--send-frame process payload 10))
-    (10 nil)
-    ((or 0 1)
-     (let ((fragments (append (process-get process 'magnus-codex-fragments)
-                              (list payload))))
-       (if (not fin)
-           (process-put process 'magnus-codex-fragments fragments)
-         (process-put process 'magnus-codex-fragments nil)
-         (condition-case err
-             (magnus-codex--dispatch-message
-              process
-              (magnus-codex--parse-line
-               (decode-coding-string (apply #'concat fragments) 'utf-8 t)))
-           (error
-            (when-let ((instance
-                        (process-get process 'magnus-codex-instance)))
-              (magnus-codex--insert
-               instance
-               (format "\n[protocol error] %s\n" (error-message-string err))
-               'error)))))))
-    (_ nil)))
-
-(defun magnus-codex--dispatch-message (process message)
-  "Dispatch parsed JSON-RPC MESSAGE received from PROCESS."
-  (let ((id (alist-get 'id message))
-        (method (alist-get 'method message))
-        (params (alist-get 'params message)))
-    (cond
-     ((and method id)
-      (magnus-codex--handle-server-request process id method params))
-     (method
-      (magnus-codex--handle-notification process method params))
-     (id
-      (let* ((pending (process-get process 'magnus-codex-pending))
-             (callback (gethash id pending)))
-        (when callback
-          (remhash id pending)
-          (funcall callback (alist-get 'result message)
-                   (alist-get 'error message))))))))
-
-(defun magnus-codex--approval-method-p (method)
-  "Return non-nil when METHOD is a supported approval request."
-  (member method '("item/commandExecution/requestApproval"
-                   "item/fileChange/requestApproval"
-                   "item/permissions/requestApproval")))
-
-(defun magnus-codex--handle-server-request (process id method params)
-  "Handle server request ID METHOD PARAMS from PROCESS."
-  (let* ((instance (process-get process 'magnus-codex-instance))
-         (thread-id (alist-get 'threadId params))
-         (owned-thread (magnus-instance-session-id instance)))
-    (if (and (magnus-codex--approval-method-p method)
-             owned-thread
-             (equal thread-id owned-thread))
-        (progn
-          (let* ((key (cons (magnus-instance-id instance) id))
-                 (token (secure-hash
-                         'sha256
-                         (format "%s:%s:%s:%s" (car key) id
-                                 (float-time) (random)))))
-            (puthash id (list :instance instance :process process
-                              :method method :params params :token token
-                              :requires-token
-                              (gethash key magnus-codex--retired-approval-ids))
-                   (magnus-codex--approval-table process))
-            (remhash key magnus-codex--retired-approval-ids))
-          (magnus-codex--insert
-           instance
-           (format "\n[approval pending] %s\n%s\n"
-                   method (magnus-codex--approval-summary params))
-           'warning)
-          (let ((token (plist-get
-                        (gethash id (magnus-codex--approval-table process))
-                        :token)))
-            (let ((magnus-codex-current-approval-token token))
-              (run-hook-with-args 'magnus-codex-approval-request-hook
-                                  instance id method params))
-            (when magnus-codex-approval-handler
-              (let ((handler magnus-codex-approval-handler))
-                (run-at-time
-                 0 nil
-                 (lambda ()
-                   (let ((magnus-codex-current-approval-token token))
-                     (funcall handler instance id method params))))))))
-      (magnus-codex--insert instance
-                            (format "\n[unsupported server request] %s\n"
-                                    method)
-                            'warning)
-      (magnus-codex--send-object
-       process `((jsonrpc . "2.0") (id . ,id)
-                 (error . ((code . -32601)
-                           (message . "Unsupported or misrouted server request"))))))))
-
-(defun magnus-codex--approval-summary (params)
-  "Return a readable summary of approval PARAMS."
-  (string-join
-   (delq nil
-         (list (when-let ((command (alist-get 'command params)))
-                 (cond
-                  ((stringp command) command)
-                  ((listp command)
-                   (string-join (mapcar (lambda (arg) (format "%s" arg))
-                                        command)
-                                " "))
-                  (t (format "%s" command))))
-               (when-let ((cwd (alist-get 'cwd params)))
-                 (format "cwd: %s" cwd))
-               (when-let ((reason (alist-get 'reason params))) reason)))
-   "\n"))
-
-(defun magnus-codex-approval-token (instance request-id)
-  "Return the generation token for INSTANCE's pending REQUEST-ID.
-Custom handlers that retain an approval for later should retain this token and
-pass it back to `magnus-codex-respond-approval'."
-  (when-let* ((process (magnus-codex--connection instance))
-              (entry (gethash request-id
-                              (magnus-codex--approval-table process))))
-    (plist-get entry :token)))
-
-(defun magnus-codex--command-approval-decision-p (decision)
-  "Return non-nil when DECISION has a current command approval shape."
-  (or (member decision '("accept" "acceptForSession" "decline" "cancel"))
-      (and (listp decision)
-           (or (alist-get 'acceptWithExecpolicyAmendment decision)
-               (alist-get 'applyNetworkPolicyAmendment decision)))))
-
-(defun magnus-codex-respond-approval (instance request-id decision
-                                               &optional generation-token)
-  "Respond to INSTANCE approval REQUEST-ID with DECISION.
-DECISION is normally accept, acceptForSession, decline, cancel, or one of the
-structured policy-amendment decisions advertised by App Server.  A permission-
-profile request instead requires its complete response alist.
-Delayed handlers should also supply GENERATION-TOKEN, obtained from
-`magnus-codex-approval-token', so a reconnect cannot redirect their answer."
-  (let* ((process (magnus-codex--connection instance))
-         (table (and process (magnus-codex--approval-table process)))
-         (entry (and table (gethash request-id table)))
-         (owner (plist-get entry :instance))
-         (method (plist-get entry :method))
-         (result (if (equal method "item/permissions/requestApproval")
-                     decision
-                   `((decision . ,decision)))))
-    (unless (and entry (eq owner instance))
-      (user-error "No pending Codex approval %s for this instance" request-id))
-    (when (and (plist-get entry :requires-token)
-               (not (equal generation-token (plist-get entry :token))))
-      (user-error
-       "Approval %s was reused after reconnect; a generation token is required"
-       request-id))
-    (when (and generation-token
-               (not (equal generation-token (plist-get entry :token))))
-      (user-error "Stale Codex approval %s for this connection" request-id))
-    (when (and (equal method "item/permissions/requestApproval")
-               (not (and (listp decision)
-                         (alist-get 'permissions decision))))
-      (user-error "Permission approval requires a response alist with permissions"))
-    (when (and (not (equal method "item/permissions/requestApproval"))
-               (not (magnus-codex--command-approval-decision-p decision)))
-      (user-error "Unsupported Codex approval decision: %s" decision))
-    (magnus-codex--send-object
-     process `((jsonrpc . "2.0") (id . ,request-id)
-               (result . ,result)))
-    (remhash request-id table)
-    (magnus-codex--insert instance
-                          (format "[approval answered: %s]\n" decision)
-                          'font-lock-comment-face)))
-
-(defun magnus-codex--turn-id (turn)
-  "Extract an ID from TURN."
-  (and (listp turn) (alist-get 'id turn)))
-
-(defun magnus-codex--handle-notification (process method params)
-  "Handle METHOD notification with PARAMS from PROCESS."
-  (let ((instance (process-get process 'magnus-codex-instance)))
-    (pcase method
-      ("item/agentMessage/delta"
-       (magnus-codex--insert instance (or (alist-get 'delta params) "")))
-      ("thread/started"
-       (when-let ((thread-id (alist-get 'id (alist-get 'thread params))))
-         (when (equal thread-id (magnus-instance-session-id instance))
-           (magnus-codex--insert
-            instance (format "[observer subscribed to thread: %s]\n" thread-id)
-            'font-lock-comment-face))))
-      ("turn/plan/updated"
-       (magnus-codex--insert instance
-                             (magnus-codex--format-plan params)
-                             'font-lock-comment-face))
-      ("turn/started"
-       (process-put process 'magnus-codex-turn-starting nil)
-       (let ((turn-id (magnus-codex--turn-id (alist-get 'turn params))))
-         (when turn-id
-           (puthash (magnus-instance-id instance) turn-id
-                    magnus-codex--active-turns)))
-       (magnus-codex--insert instance "\n[turn started]\n"
-                             'font-lock-comment-face))
-      ("turn/completed"
-       (remhash (magnus-instance-id instance) magnus-codex--active-turns)
-       (process-put process 'magnus-codex-turn-starting nil)
-       (magnus-codex--insert instance "\n[turn completed]\n\n"
-                             'font-lock-comment-face))
-      ("thread/status/changed"
-       (magnus-codex--insert
-        instance (format "\n[status: %s]\n"
-                         (magnus-codex--thread-status-name
-                          (alist-get 'status params)))
-        'font-lock-comment-face))
-      ("error"
-       (magnus-codex--insert instance
-                             (format "\n[Codex error] %s\n"
-                                     (or (alist-get 'message
-                                                    (alist-get 'error params))
-                                         params))
-                             'error)))
-    (run-hook-with-args 'magnus-codex-event-hook instance method params)))
-
-(defun magnus-codex--thread-status-name (status)
-  "Return the readable type name from App Server STATUS."
-  (if (listp status)
-      (or (alist-get 'type status) "unknown")
-    (or status "unknown")))
-
-(defun magnus-codex--format-plan (params)
-  "Format plan notification PARAMS for the output buffer."
-  (concat
-   "\n[plan]\n"
-   (mapconcat
-    (lambda (step)
-      (format "  %-11s %s" (or (alist-get 'status step) "")
-              (or (alist-get 'step step) "")))
-    (alist-get 'plan params) "\n")
-   "\n"))
-
-(defun magnus-codex--sentinel (process event)
-  "Handle observer PROCESS termination EVENT."
-  (unless (process-live-p process)
-    (when-let ((instance (process-get process 'magnus-codex-instance)))
-      (magnus-codex--cancel-startup-timeout process)
-      (let ((current
-             (eq process (gethash (magnus-instance-id instance)
-                                  magnus-codex--connections))))
-        (when current
-          (remhash (magnus-instance-id instance) magnus-codex--connections)
-          (remhash (magnus-instance-id instance) magnus-codex--active-turns))
-        ;; Approval retirement is process-local and remains necessary even for
-        ;; a stale sentinel.  Instance-global lifecycle state is current-only.
-        (magnus-codex--clear-approvals instance process)
-        ;; Once the TUI owns the thread, observer failure must not terminate or
-        ;; misreport the interactive session.  Before that handoff it is fatal.
-        (when (and current
-                   (not (magnus-codex--tui-process instance))
-                   (not (eq (magnus-instance-status instance) 'purged)))
-          (magnus-instances-update instance :status 'stopped)))
-      (unless (process-get process 'magnus-codex-intentional-stop)
-        (magnus-codex--insert instance (format "\n[observer %s]" event)
-                              'font-lock-comment-face))
-      (when (and (boundp 'magnus-buffer-name)
-                 (get-buffer magnus-buffer-name))
-        (magnus-status-refresh)))))
-
-(defun magnus-codex--clear-approvals (instance &optional process)
-  "Retire and remove pending approvals owned by INSTANCE."
-  (when-let ((connection
-              (or process
-                  (gethash (magnus-instance-id instance)
-                           magnus-codex--connections))))
-    (let ((table (magnus-codex--approval-table connection))
-          (instance-id (magnus-instance-id instance)))
-      (maphash
-       (lambda (request-id _entry)
-         (puthash (cons instance-id request-id) t
-                  magnus-codex--retired-approval-ids))
-       table)
-      (clrhash table))))
-
-(defun magnus-codex--default-socket ()
-  "Return the managed App Server daemon's standard Unix socket path."
-  (expand-file-name
-   "app-server-control/app-server-control.sock"
-   (or (getenv "CODEX_HOME") (expand-file-name ".codex" "~"))))
-
-(defun magnus-codex--remote-socket ()
-  "Return the Unix socket selected by `magnus-codex-remote'."
-  (cond
-   ((equal magnus-codex-remote "unix://")
-    (magnus-codex--default-socket))
-   ((string-match "\\`unix://\\(.+\\)\\'" magnus-codex-remote)
-    (let ((path (match-string 1 magnus-codex-remote)))
-      (unless (file-name-absolute-p path)
-        (user-error "Codex custom Unix socket must be absolute: %s" path))
-      path))
-   (t
-    (user-error "Magnus observer supports unix:// endpoints, not %s"
-                magnus-codex-remote))))
-
-(defun magnus-codex--socket-live-p (socket)
-  "Return non-nil when a local listener accepts connections at SOCKET."
-  (condition-case nil
-      (let ((probe (make-network-process
-                    :name "magnus-codex-socket-probe"
-                    :family 'local :service socket
-                    :coding 'binary :noquery t)))
-        (delete-process probe)
-        t)
-    (file-error nil)))
-
-(defun magnus-codex--ensure-daemon ()
-  "Ensure the selected local App Server endpoint is healthy.
-Return its Unix socket path."
-  (unless (executable-find magnus-codex-executable)
-    (user-error "Cannot find Codex executable: %s" magnus-codex-executable))
-  (let ((socket (magnus-codex--remote-socket)))
-    (if (equal magnus-codex-remote "unix://")
-        (unless (magnus-codex--socket-live-p socket)
-          (with-temp-buffer
-            (let ((status (process-file magnus-codex-executable nil t nil
-                                        "app-server" "daemon" "start")))
-              (unless (and (integerp status) (zerop status)
-                           (magnus-codex--socket-live-p socket))
-                (user-error "Could not start Codex App Server daemon: %s"
-                            (string-trim (buffer-string)))))))
-      (unless (magnus-codex--socket-live-p socket)
-        (user-error "No Codex App Server is listening at %s" socket)))
-    socket))
-
-(defun magnus-codex--cancel-startup-timeout (process)
-  "Cancel PROCESS's startup deadline, when present."
-  (when-let ((timer (process-get process 'magnus-codex-startup-timer)))
+(defun magnus-codex--cancel-timer (process property)
+  "Cancel PROCESS timer stored under PROPERTY, if any."
+  (when-let ((timer (process-get process property)))
     (cancel-timer timer)
-    (process-put process 'magnus-codex-startup-timer nil)))
+    (process-put process property nil)))
 
-(defun magnus-codex--arm-startup-timeout (process instance)
-  "Fail PROCESS startup after the configured deadline for INSTANCE."
-  (process-put
-   process 'magnus-codex-startup-timer
-   (run-at-time
-    magnus-codex-startup-timeout nil
-    (lambda ()
-      (when (and (process-live-p process)
-                 (eq process (magnus-codex--connection instance))
-                 (not (magnus-codex--tui-process instance)))
-        (magnus-codex--insert
-         instance
-         (format "[startup timed out after %.1f seconds]\n"
-                 magnus-codex-startup-timeout)
-         'error)
-        (process-put process 'magnus-codex-intentional-stop t)
-        (delete-process process)
-        (unless (eq (magnus-instance-status instance) 'purged)
-          (magnus-instances-update instance :status 'stopped :buffer nil)))))))
+(defun magnus-codex--session-root ()
+  "Return the root containing Codex rollout records."
+  (expand-file-name
+   "sessions" (or (getenv "CODEX_HOME") (expand-file-name ".codex" "~"))))
 
-(defun magnus-codex--register-connection (instance process)
-  "Install PROCESS as INSTANCE's observer after retiring an older generation."
-  (let* ((id (magnus-instance-id instance))
-         (old (gethash id magnus-codex--connections)))
-    (when (and old (not (eq old process)))
-      (magnus-codex--clear-approvals instance old))
-    (puthash id process magnus-codex--connections)))
+(defun magnus-codex--session-directories ()
+  "Return possible recent local and UTC Codex session directories."
+  (let ((root (magnus-codex--session-root))
+        (now (current-time)))
+    (mapcar (lambda (date) (expand-file-name date root))
+            (delete-dups
+             (cl-loop for time in (list now (time-subtract now 86400))
+                      append (list (format-time-string "%Y/%m/%d" time)
+                                   (format-time-string "%Y/%m/%d" time t)))))))
 
-(defun magnus-codex--start-process (instance socket)
-  "Start INSTANCE's semantic observer proxy to the managed daemon."
-  (let* ((name (format "magnus-codex-%s" (magnus-instance-id instance)))
-         (stderr (get-buffer-create (format " *%s-stderr*" name)))
-         (default-directory (magnus-instance-directory instance))
-         (command (append
-                   (list magnus-codex-executable "app-server" "proxy")
-                   (unless (equal socket (magnus-codex--default-socket))
-                     (list "--sock" socket))))
-         (process (make-process
-                   :name name
-                   :command command
-                   :connection-type 'pipe
-                   :coding 'binary
-                   :noquery t
-                   :buffer nil
-                   :stderr stderr
-                   :filter #'magnus-codex--filter
-                   :sentinel #'magnus-codex--sentinel)))
-    (process-put process 'magnus-codex-instance instance)
-    (process-put process 'magnus-codex-pending (make-hash-table :test #'equal))
-    (process-put process 'magnus-codex-approvals
-                 (make-hash-table :test #'equal))
-    (process-put process 'magnus-codex-next-id 0)
-    (process-put process 'magnus-codex-handshake-buffer
-                 (magnus-codex--byte-string))
-    (process-put process 'magnus-codex-frame-buffer
-                 (magnus-codex--byte-string))
-    (process-put process 'magnus-codex-websocket-ready nil)
-    (process-put process 'magnus-codex-turn-starting nil)
-    (magnus-codex--register-connection instance process)
-    (magnus-codex--arm-startup-timeout process instance)
-    process))
+(defun magnus-codex--session-files ()
+  "Return current Codex rollout files that may belong to a new launch."
+  (apply
+   #'append
+   (mapcar
+    (lambda (directory)
+      (when (file-directory-p directory)
+        (directory-files directory t "\\`rollout-.*\\.jsonl\\'")))
+    (magnus-codex--session-directories))))
 
-(defun magnus-codex-start (instance &optional initial-message)
-  "Start or resume Codex INSTANCE in a TUI.
-INITIAL-MESSAGE, when non-nil, is submitted by the TUI as its first prompt."
-  (when (or (magnus-codex--connection instance)
-            (magnus-codex--tui-process instance))
-    (user-error "Codex instance `%s' is already running"
-                (magnus-instance-name instance)))
-  (let* ((socket (magnus-codex--ensure-daemon))
-         (process (magnus-codex--start-process instance socket)))
-    (process-put process 'magnus-codex-on-open
-                 (lambda ()
-                   (magnus-codex--initialize
-                    process instance initial-message)))
-    (magnus-codex--websocket-handshake process)
-    process))
+(defun magnus-codex--read-json-line ()
+  "Read the JSON object on the current line, returning nil when incomplete."
+  (condition-case nil
+      (let ((json-object-type 'alist)
+            (json-array-type 'list)
+            (json-key-type 'symbol)
+            (json-false nil)
+            (json-null nil))
+        (json-read-from-string
+         (buffer-substring-no-properties
+          (line-beginning-position) (line-end-position))))
+    (error
+     ;; Rollout lines may be observed before Codex finishes writing them.
+     nil)))
 
-(defun magnus-codex--initialize (process instance initial-message)
-  "Initialize observer PROCESS, then open INSTANCE with INITIAL-MESSAGE."
-  (magnus-codex--request
-   process "initialize"
-   '((clientInfo . ((name . "magnus") (title . "Magnus")
-                    (version . "0.1.0")))
-     (capabilities . ((experimentalApi . :json-false))))
-   (lambda (_result error)
-     (if error
-         (progn
-           (magnus-codex--insert instance
-                                 (format "[initialize failed] %s\n" error)
-                                 'error)
-           (delete-process process))
-       (magnus-codex--notify process "initialized")
-       (if (magnus-instance-session-id instance)
-           (magnus-codex--resume-observer-thread
-            process instance initial-message)
-         (magnus-codex--create-observer-thread
-          process instance initial-message))))))
+(defun magnus-codex--same-directory-p (first second)
+  "Return non-nil when FIRST and SECOND name the same directory."
+  (when (and (stringp first) (stringp second))
+    (condition-case nil
+        (equal (file-truename first) (file-truename second))
+      (file-error
+       (equal (directory-file-name (expand-file-name first))
+              (directory-file-name (expand-file-name second)))))))
 
-(defun magnus-codex--startup-failed (process instance phase error)
-  "Record startup ERROR during PHASE and stop observer PROCESS for INSTANCE."
-  (magnus-codex--insert instance (format "[%s failed] %s\n" phase error) 'error)
-  (when (process-live-p process)
-    (delete-process process)))
+(defun magnus-codex--session-id-from-file (file directory prompt)
+  "Return FILE's top-level Codex session ID for DIRECTORY and PROMPT.
+Only the initial metadata and first user message are examined."
+  (condition-case nil
+      (with-temp-buffer
+        ;; The initial prompt is recorded near the beginning of a rollout.
+        (insert-file-contents file nil 0 magnus-codex--session-scan-limit)
+        (goto-char (point-min))
+        (let* ((metadata (magnus-codex--read-json-line))
+               (payload (and (equal (alist-get 'type metadata) "session_meta")
+                             (alist-get 'payload metadata)))
+               (id (alist-get 'id payload))
+               (session-id (alist-get 'session_id payload))
+               user-message)
+          (when (and id
+                     (equal id session-id)
+                     (null (alist-get 'parent_thread_id payload))
+                     (magnus-codex--same-directory-p
+                      directory (alist-get 'cwd payload)))
+            (forward-line 1)
+            (while (and (not user-message) (not (eobp)))
+              (let* ((record (magnus-codex--read-json-line))
+                     (event (and (equal (alist-get 'type record) "event_msg")
+                                 (alist-get 'payload record))))
+                (when (equal (alist-get 'type event) "user_message")
+                  (setq user-message (alist-get 'message event))))
+              (forward-line 1))
+            (and (equal user-message prompt) id))))
+    (error
+     ;; A concurrently written rollout is retried on the next bounded poll.
+     nil)))
 
-(defun magnus-codex--create-observer-thread (process instance initial-message)
-  "Create and subscribe PROCESS to a new thread before opening INSTANCE's TUI."
-  (magnus-codex--request
-   process "thread/start"
-   `((cwd . ,(magnus-instance-directory instance))
-     (developerInstructions . ,(magnus-codex--instructions instance)))
-   (lambda (result error)
-     (cond
-      (error
-       (magnus-codex--startup-failed process instance "thread/start" error))
-      ((not (eq process (magnus-codex--connection instance))) nil)
-      (t
-       (let ((thread-id (alist-get 'id (alist-get 'thread result))))
-         (if (not thread-id)
-             (magnus-codex--startup-failed
-              process instance "thread/start" "response contained no thread ID")
-           (magnus-instances-update instance :session-id thread-id)
-           (magnus-codex--insert
-            instance (format "[observer created thread: %s]\n" thread-id)
-            'font-lock-comment-face)
-           (magnus-codex--spawn-tui
-            instance (magnus-codex--onboarding-prompt
-                      instance initial-message)))))))))
+(defun magnus-codex--find-session-id (instance prompt files-before)
+  "Find INSTANCE's new session for PROMPT, excluding FILES-BEFORE."
+  (let ((candidates
+         (cl-set-difference (magnus-codex--session-files) files-before
+                            :test #'string=)))
+    (cl-loop for file in candidates
+             thereis (magnus-codex--session-id-from-file
+                      file (magnus-instance-directory instance) prompt))))
 
-(defun magnus-codex--resume-observer-thread (process instance initial-message)
-  "Subscribe PROCESS to INSTANCE's saved thread before opening its TUI."
-  (let ((thread-id (magnus-instance-session-id instance)))
-    (magnus-codex--request
-     process "thread/resume" `((threadId . ,thread-id))
-     (lambda (_result error)
-       (cond
-        (error
-         (magnus-codex--startup-failed process instance "thread/resume" error))
-        ((not (eq process (magnus-codex--connection instance))) nil)
-        (t
-         (magnus-codex--insert
-          instance (format "[observer resumed thread: %s]\n" thread-id)
-          'font-lock-comment-face)
-         (magnus-codex--spawn-tui instance initial-message)))))))
+(defun magnus-codex--finish-session-capture (process)
+  "Release session-capture state owned by PROCESS."
+  (magnus-codex--cancel-timer process 'magnus-codex-capture-timer)
+  (process-put process 'magnus-codex-capture-prompt nil)
+  (process-put process 'magnus-codex-files-before nil)
+  (process-put process 'magnus-codex-capture-deadline nil))
 
-(defun magnus-codex--onboarding-prompt (instance &optional initial-message)
-  "Return durable first-turn onboarding for INSTANCE and INITIAL-MESSAGE.
-The den contract is also made visible and persistent in user history."
-  (concat
-   (magnus-codex--instructions instance)
-   (if initial-message
-       (concat "\n\nInitial task from the user:\n" initial-message)
-     (concat "\n\nNo separate task was supplied. Complete your orientation, "
-             "report that you are ready, and then wait for the user."))))
+(defun magnus-codex--poll-session (process)
+  "Capture the new Codex session ID owned by PROCESS."
+  (let ((instance (process-get process 'magnus-codex-instance)))
+    (cond
+     ((not (magnus-codex--current-process-p process instance))
+      (magnus-codex--finish-session-capture process))
+     ((when-let ((session-id
+                  (magnus-codex--find-session-id
+                   instance
+                   (process-get process 'magnus-codex-capture-prompt)
+                   (process-get process 'magnus-codex-files-before))))
+        (magnus-instances-update instance :session-id session-id)
+        (message "Magnus: captured Codex session %s for %s"
+                 session-id (magnus-instance-name instance))
+        (magnus-codex--finish-session-capture process)
+        t))
+     ((> (float-time) (process-get process 'magnus-codex-capture-deadline))
+      (magnus-codex--finish-session-capture process)
+      (message
+       "Magnus: could not capture the Codex session for %s; the TUI remains usable"
+       (magnus-instance-name instance))))))
 
-(defun magnus-codex--tui-command (instance &optional initial-message)
-  "Return the shell command used to run INSTANCE's new or resumed TUI.
-INITIAL-MESSAGE becomes the optional initial prompt."
-  (let ((thread-id (magnus-instance-session-id instance)))
-    (mapconcat
-     #'shell-quote-argument
-     (append (list "exec" magnus-codex-executable)
-             (when thread-id (list "resume"))
-             (list "--remote" magnus-codex-remote
-                   "-C" (magnus-instance-directory instance))
-             (when thread-id (list thread-id))
-             (when initial-message (list initial-message)))
-     " ")))
-
-(defun magnus-codex--spawn-tui (instance &optional initial-message)
-  "Launch INSTANCE's full Codex TUI, optionally with INITIAL-MESSAGE."
-  (let* ((buffer-name (format "*codex:%s*" (magnus-instance-name instance)))
-         (default-directory (magnus-instance-directory instance))
-         (buffer (magnus-process--create-vterm-buffer buffer-name))
-         (command (magnus-codex--tui-command instance initial-message)))
-    (when-let ((observer (magnus-codex--connection instance)))
-      (magnus-codex--cancel-startup-timeout observer))
-    (remhash (magnus-instance-id instance) magnus-codex--tui-ready)
-    (with-current-buffer buffer
-      (setq-local magnus-codex--instance instance))
-    ;; A freshly created vterm may still be initializing its login shell.  Give
-    ;; it one tick before pasting, then another before submitting the command.
-    (run-with-timer
-     0.1 nil
-     (lambda ()
-       (when (buffer-live-p buffer)
-         (with-current-buffer buffer
-           (vterm-send-string command)))))
-    (run-with-timer
-     0.5 nil
-     (lambda ()
-       (when (buffer-live-p buffer)
-         (with-current-buffer buffer
-           (vterm-send-return))
-         (run-with-timer
-          magnus-codex-tui-ready-delay nil
-          (lambda ()
-            (when (and (buffer-live-p buffer)
-                       (eq buffer (magnus-instance-buffer instance))
-                       (magnus-codex--tui-process instance))
-              (puthash (magnus-instance-id instance) t
-                       magnus-codex--tui-ready)
-              (magnus-codex--drain-input-queue instance)))))))
-    (magnus-instances-update instance :buffer buffer :status 'running)
-    (magnus-codex--setup-tui-sentinel instance buffer)
-    (when (gethash (magnus-instance-id instance) magnus-codex--show-on-ready)
-      (remhash (magnus-instance-id instance) magnus-codex--show-on-ready)
-      (pop-to-buffer buffer))
-    (when (and (boundp 'magnus-buffer-name)
-               (get-buffer magnus-buffer-name))
-      (magnus-status-refresh))
-    buffer))
-
-(defun magnus-codex--setup-tui-sentinel (instance buffer)
-  "Track the interactive Codex process for INSTANCE in BUFFER."
-  (when-let ((process (get-buffer-process buffer)))
-    (process-put process 'magnus-codex-observer
-                 (magnus-codex--connection instance))
-    (set-process-sentinel
-     process
-     (lambda (terminal _event)
-       (unless (process-live-p terminal)
-         (when-let ((observer
-                     (process-get terminal 'magnus-codex-observer)))
-           (process-put observer 'magnus-codex-intentional-stop t)
-           (when (process-live-p observer)
-             (delete-process observer)))
-         ;; A stale vterm can report its exit after a replacement TUI exists.
-         ;; Only the terminal still owned by INSTANCE may release or stop it.
-         (when (and (buffer-live-p (magnus-instance-buffer instance))
-                    (eq terminal
-                        (get-buffer-process
-                         (magnus-instance-buffer instance))))
-           (remhash (magnus-instance-id instance) magnus-codex--tui-ready)
-           (remhash (magnus-instance-id instance) magnus-codex--input-busy)
-           (when-let ((timer
-                       (gethash (magnus-instance-id instance)
-                                magnus-codex--input-retry)))
-             (cancel-timer timer))
-           (remhash (magnus-instance-id instance) magnus-codex--input-retry)
-           (remhash (magnus-instance-id instance) magnus-codex--input-queues)
-           (unless (eq (magnus-instance-status instance) 'purged)
-             (magnus-instances-update instance :status 'stopped))
-           (when (and (boundp 'magnus-buffer-name)
-                      (get-buffer magnus-buffer-name))
-             (magnus-status-refresh))))))))
+(defun magnus-codex--watch-for-session (process instance prompt files-before)
+  "Watch PROCESS for INSTANCE's session matching PROMPT.
+FILES-BEFORE contains rollout files that predate this launch."
+  (process-put process 'magnus-codex-instance instance)
+  (process-put process 'magnus-codex-capture-prompt prompt)
+  (process-put process 'magnus-codex-files-before files-before)
+  (process-put process 'magnus-codex-capture-deadline
+               (+ (float-time) magnus-codex-session-capture-timeout))
+  (process-put process 'magnus-codex-capture-timer
+               (run-at-time 0.5 0.5 #'magnus-codex--poll-session process)))
 
 (defun magnus-codex--instructions (instance)
   "Build Magnus identity and coordination instructions for Codex INSTANCE."
@@ -1006,224 +271,227 @@ INITIAL-MESSAGE becomes the optional initial prompt."
      (when magnus-codex-extra-developer-instructions
        (concat "\n\n" magnus-codex-extra-developer-instructions)))))
 
-(defun magnus-codex--input (text)
-  "Build App Server user input for TEXT."
-  `[((type . "text") (text . ,text))])
+(defun magnus-codex--launch-marker (instance)
+  "Return a unique session-correlation marker for INSTANCE."
+  (concat "magnus-session-marker:"
+          (secure-hash
+           'sha256
+           (format "%s:%s:%s" (magnus-instance-id instance)
+                   (float-time) (random)))))
+
+(defun magnus-codex--onboarding-prompt (instance initial-message marker)
+  "Return first-turn onboarding for INSTANCE, INITIAL-MESSAGE, and MARKER."
+  (concat
+   (magnus-codex--instructions instance)
+   (if initial-message
+       (concat "\n\nInitial task from the user:\n" initial-message)
+     (concat "\n\nNo separate task was supplied. Complete your orientation, "
+             "report that you are ready, and then wait for the user."))
+   "\n\nInternal Magnus session marker: " marker
+   ". Leave this marker in the session history; do not repeat it in replies."))
+
+(defun magnus-codex--tui-command (instance &optional initial-message)
+  "Return the shell command for INSTANCE and optional INITIAL-MESSAGE."
+  (let ((session-id (magnus-instance-session-id instance)))
+    (mapconcat
+     #'shell-quote-argument
+     (append (list "exec" magnus-codex-executable)
+             (when session-id (list "resume"))
+             (list "-C" (magnus-instance-directory instance))
+             (when session-id (list session-id))
+             (when initial-message (list initial-message)))
+     " ")))
+
+(defun magnus-codex--setup-tui-sentinel (instance buffer)
+  "Track INSTANCE's interactive Codex process in BUFFER."
+  (when-let ((process (get-buffer-process buffer)))
+    (process-put process 'magnus-codex-instance instance)
+    (set-process-sentinel
+     process
+     (lambda (terminal _event)
+       (unless (process-live-p terminal)
+         (dolist (property '(magnus-codex-capture-timer
+                             magnus-codex-ready-timer
+                             magnus-codex-input-retry-timer
+                             magnus-codex-input-busy-timer))
+           (magnus-codex--cancel-timer terminal property))
+         ;; A replaced vterm may report its exit after a new TUI is running.
+         (when (and (buffer-live-p (magnus-instance-buffer instance))
+                    (eq terminal (get-buffer-process
+                                  (magnus-instance-buffer instance))))
+           (unless (eq (magnus-instance-status instance) 'purged)
+             (magnus-instances-update instance :status 'stopped))
+           (when (and (boundp 'magnus-buffer-name)
+                      (get-buffer magnus-buffer-name))
+             (magnus-status-refresh))))))))
+
+(defun magnus-codex--spawn-tui (instance prompt &optional marker files-before)
+  "Launch INSTANCE's native TUI with PROMPT.
+When MARKER is non-nil, capture its new session against FILES-BEFORE."
+  (let* ((buffer-name (format "*codex:%s*" (magnus-instance-name instance)))
+         (default-directory (magnus-instance-directory instance))
+         (buffer (magnus-process--create-vterm-buffer buffer-name))
+         (command (magnus-codex--tui-command instance prompt))
+         (process (get-buffer-process buffer)))
+    (unless (process-live-p process)
+      (kill-buffer buffer)
+      (user-error "Could not start a vterm for Codex instance `%s'"
+                  (magnus-instance-name instance)))
+    (with-current-buffer buffer
+      (setq-local magnus-codex--instance instance))
+    (magnus-instances-update instance :buffer buffer :status 'running)
+    (magnus-codex--setup-tui-sentinel instance buffer)
+    (when marker
+      (magnus-codex--watch-for-session process instance prompt files-before))
+    ;; Give vterm's login shell one tick before replacing it with Codex.
+    (run-with-timer
+     0.1 nil
+     (lambda ()
+       (when (magnus-codex--current-process-p process instance)
+         (with-current-buffer buffer
+           (vterm-send-string command)))))
+    (run-with-timer
+     0.5 nil
+     (lambda ()
+       (when (magnus-codex--current-process-p process instance)
+         (with-current-buffer buffer
+           (vterm-send-return))
+         (process-put
+          process 'magnus-codex-ready-timer
+          (run-with-timer
+           magnus-codex-tui-ready-delay nil
+           (lambda ()
+             (when (magnus-codex--current-process-p process instance)
+               (process-put process 'magnus-codex-ready-timer nil)
+               (process-put process 'magnus-codex-ready t)
+               (magnus-codex--drain-input-queue process))))))))
+    (when (and (boundp 'magnus-buffer-name)
+               (get-buffer magnus-buffer-name))
+      (magnus-status-refresh))
+    buffer))
+
+(defun magnus-codex-start (instance &optional initial-message)
+  "Start or resume Codex INSTANCE with optional INITIAL-MESSAGE."
+  (when (magnus-codex-running-p instance)
+    (user-error "Codex instance `%s' is already running"
+                (magnus-instance-name instance)))
+  (unless (executable-find magnus-codex-executable)
+    (user-error "Cannot find Codex executable: %s" magnus-codex-executable))
+  (when-let ((old-buffer (magnus-instance-buffer instance)))
+    (when (buffer-live-p old-buffer)
+      (kill-buffer old-buffer)))
+  (if (magnus-instance-session-id instance)
+      (magnus-codex--spawn-tui instance initial-message)
+    (let* ((marker (magnus-codex--launch-marker instance))
+           (prompt (magnus-codex--onboarding-prompt
+                    instance initial-message marker))
+           (files-before (magnus-codex--session-files)))
+      (magnus-codex--spawn-tui instance prompt marker files-before))))
 
 (defun magnus-codex-send (instance text)
-  "Submit TEXT through INSTANCE's Codex TUI.
-Messages are serialized so concurrent coordination deliveries cannot merge.
-The semantic observer never starts or steers turns; the TUI remains the only
-interactive writer and Codex applies its native input semantics."
-  (let ((buffer (magnus-instance-buffer instance)))
-    (unless (and (buffer-live-p buffer) (magnus-codex--tui-process instance))
+  "Queue TEXT for serialized delivery through INSTANCE's native TUI."
+  (let ((process (magnus-codex--tui-process instance)))
+    (unless process
       (user-error "Codex instance `%s' is not running"
                   (magnus-instance-name instance)))
-    (let* ((id (magnus-instance-id instance))
-           (queue (gethash id magnus-codex--input-queues)))
-      (puthash id (append queue (list text)) magnus-codex--input-queues)
-      (magnus-codex--drain-input-queue instance))))
+    (process-put process 'magnus-codex-input-queue
+                 (append (process-get process 'magnus-codex-input-queue)
+                         (list text)))
+    (magnus-codex--drain-input-queue process)))
 
-(defun magnus-codex--drain-input-queue (instance)
-  "Submit the next queued TUI message for INSTANCE, if it is safe to do so."
-  (let* ((id (magnus-instance-id instance))
-         (buffer (magnus-instance-buffer instance))
-         (queue (gethash id magnus-codex--input-queues)))
+(defun magnus-codex--drain-input-queue (process)
+  "Submit PROCESS's next queued TUI message when it is safe."
+  (let* ((instance (process-get process 'magnus-codex-instance))
+         (buffer (and instance (magnus-instance-buffer instance)))
+         (queue (process-get process 'magnus-codex-input-queue)))
     (when (and queue
-               (gethash id magnus-codex--tui-ready)
-               (not (gethash id magnus-codex--input-busy))
-               (buffer-live-p buffer)
-               (magnus-codex--tui-process instance))
+               (process-get process 'magnus-codex-ready)
+               (not (process-get process 'magnus-codex-input-busy))
+               (magnus-codex--current-process-p process instance))
       (if (eq buffer (window-buffer (selected-window)))
-          ;; Never append to or submit a composer while the user is actively in
-          ;; that TUI.  Retry once they move away.
-          (unless (gethash id magnus-codex--input-retry)
-            (puthash
-             id
+          ;; Do not append to a composer while the user owns this TUI.
+          (unless (process-get process 'magnus-codex-input-retry-timer)
+            (process-put
+             process 'magnus-codex-input-retry-timer
              (run-with-timer
               1.0 nil
               (lambda ()
-                (remhash id magnus-codex--input-retry)
-                (magnus-codex--drain-input-queue instance)))
-             magnus-codex--input-retry))
-        (let ((text (car queue)))
-          (puthash id (cdr queue) magnus-codex--input-queues)
-          (puthash id t magnus-codex--input-busy)
-          ;; Bracketed paste and Return are emitted in one Emacs event, so user
-          ;; keystrokes cannot interleave two Magnus deliveries.
-          (with-current-buffer buffer
-            (vterm-send-string text t)
-            (vterm-send-return))
-          (run-with-timer
-           0.1 nil
-           (lambda ()
-             (remhash id magnus-codex--input-busy)
-             (magnus-codex--drain-input-queue instance))))))))
-
-(defun magnus-codex-steer (instance text &optional _expected-turn-id)
-  "Submit TEXT through INSTANCE's TUI using Codex's native active-turn UI."
-  (magnus-codex-send instance text))
+                (process-put process 'magnus-codex-input-retry-timer nil)
+                (magnus-codex--drain-input-queue process)))))
+        (process-put process 'magnus-codex-input-queue (cdr queue))
+        (process-put process 'magnus-codex-input-busy t)
+        ;; Bracketed paste and Return occur in one Emacs event, preventing two
+        ;; automated deliveries from interleaving.
+        (with-current-buffer buffer
+          (vterm-send-string (car queue) t)
+          (vterm-send-return))
+        (process-put
+         process 'magnus-codex-input-busy-timer
+         (run-with-timer
+          0.1 nil
+          (lambda ()
+            (process-put process 'magnus-codex-input-busy nil)
+            (process-put process 'magnus-codex-input-busy-timer nil)
+            (magnus-codex--drain-input-queue process))))))))
 
 (defun magnus-codex-interrupt (instance)
-  "Interrupt Codex INSTANCE semantically, falling back to its TUI."
-  (let* ((buffer (magnus-instance-buffer instance))
-         (process (magnus-codex--connection instance))
-         (thread-id (magnus-instance-session-id instance))
-         (turn-id (gethash (magnus-instance-id instance)
-                           magnus-codex--active-turns)))
-    (unless (and (buffer-live-p buffer) (magnus-codex--tui-process instance))
+  "Interrupt Codex INSTANCE through its native TUI."
+  (let ((buffer (magnus-instance-buffer instance)))
+    (unless (magnus-codex--tui-process instance)
       (user-error "Codex instance `%s' is not running"
                   (magnus-instance-name instance)))
-    (if (and process thread-id turn-id)
-        (magnus-codex--request
-         process "turn/interrupt"
-         `((threadId . ,thread-id) (turnId . ,turn-id))
-         (lambda (_result error)
-           (when error
-             (magnus-codex--insert
-              instance (format "[turn/interrupt failed] %s\n" error) 'error))))
-      (with-current-buffer buffer
-        (vterm-send-key "C-c")))))
+    (with-current-buffer buffer
+      (vterm-send-key "C-c"))))
 
-(defun magnus-codex--finalize-stop (instance observer buffer force)
-  "Close INSTANCE's captured OBSERVER and BUFFER after semantic shutdown.
+(defun magnus-codex--finish-stop (instance buffer force)
+  "Finish stopping INSTANCE's captured BUFFER.
 FORCE selects immediate process killing."
-  (when observer
-    ;; Retire request IDs before deleting or replacing this connection; its
-    ;; sentinel may run after a new observer has already received reused IDs.
-    (magnus-codex--clear-approvals instance observer)
-    (process-put observer 'magnus-codex-intentional-stop t)
-    (when (process-live-p observer)
-      (if force (kill-process observer) (delete-process observer))))
   (when (buffer-live-p buffer)
-    (when-let ((terminal (get-buffer-process buffer)))
-      (set-process-query-on-exit-flag terminal nil)
-      (when (process-live-p terminal)
-        (if force (kill-process terminal) (delete-process terminal))))
+    (when-let ((process (get-buffer-process buffer)))
+      (set-process-query-on-exit-flag process nil)
+      (when (process-live-p process)
+        (if force (kill-process process) (delete-process process))))
     (kill-buffer buffer))
-  (let* ((id (magnus-instance-id instance))
-         (current-observer (gethash id magnus-codex--connections))
-         (semantic-current
-          (or (null current-observer) (eq observer current-observer)))
-         (current-buffer (magnus-instance-buffer instance))
-         (ui-current (or (eq buffer current-buffer) (null current-buffer))))
-    (when semantic-current
-      (remhash id magnus-codex--connections))
-    (when semantic-current
-      (remhash id magnus-codex--active-turns))
-    (when ui-current
-      (remhash id magnus-codex--show-on-ready)
-      (remhash id magnus-codex--tui-ready)
-      (remhash id magnus-codex--input-busy)
-      (when-let ((timer (gethash id magnus-codex--input-retry)))
-        (cancel-timer timer))
-      (remhash id magnus-codex--input-retry)
-      (remhash id magnus-codex--input-queues))
-    (when (and semantic-current ui-current
-               (not (eq (magnus-instance-status instance) 'purged)))
+  (when (eq buffer (magnus-instance-buffer instance))
+    (unless (eq (magnus-instance-status instance) 'purged)
       (magnus-instances-update instance :status 'stopped :buffer nil))))
 
 (defun magnus-codex-stop (instance &optional force)
-  "Stop Codex INSTANCE's TUI and observer, never the shared daemon.
-When a turn is active, request `turn/interrupt' before closing the clients.
-FORCE shortens the bounded grace period and kills local subprocesses."
-  (let* ((observer (magnus-codex--connection instance))
-         (buffer (magnus-instance-buffer instance))
-         (thread-id (magnus-instance-session-id instance))
-         (turn-id (gethash (magnus-instance-id instance)
-                           magnus-codex--active-turns))
-         (finished nil))
+  "Stop Codex INSTANCE's native TUI.
+FORCE kills the terminal immediately; otherwise interrupt before closing it."
+  (let* ((buffer (magnus-instance-buffer instance))
+         (process (magnus-codex--tui-process instance)))
+    ;; Give a very short-lived session one final chance to become resumable.
+    (when (and process
+               (not (magnus-instance-session-id instance))
+               (process-get process 'magnus-codex-capture-prompt))
+      (magnus-codex--poll-session process))
     (unless (eq (magnus-instance-status instance) 'purged)
       (magnus-instances-update instance :status 'stopped))
-    (cl-labels
-        ((finish ()
-           (unless finished
-             (setq finished t)
-             (magnus-codex--finalize-stop
-              instance observer buffer force)))
-         (tui-fallback ()
-           (if (and (buffer-live-p buffer)
-                    (magnus-codex--tui-process instance))
-               (progn
-                 (with-current-buffer buffer
-                   (vterm-send-key "C-c"))
-                 (run-with-timer (if force 0.1 0.5) nil #'finish))
-             (finish))))
-      (if (and observer thread-id turn-id)
-          (condition-case err
-              (progn
-                (magnus-codex--request
-                 observer "turn/interrupt"
-                 `((threadId . ,thread-id) (turnId . ,turn-id))
-                 (lambda (_result error)
-                   (when error
-                     (magnus-codex--insert
-                      instance (format "[turn/interrupt failed] %s\n" error)
-                      'error))
-                   (if error (tui-fallback) (finish))))
-                (run-with-timer (if force 0.1 0.75) nil #'finish))
-            (error
-             (magnus-codex--insert
-              instance
-              (format "[could not request turn interruption] %s\n"
-                      (error-message-string err))
-              'error)
-             (tui-fallback)))
-        (tui-fallback)))))
+    (if (and (buffer-live-p buffer) (process-live-p process))
+        (if force
+            (magnus-codex--finish-stop instance buffer t)
+          (with-current-buffer buffer
+            (vterm-send-key "C-c"))
+          (run-with-timer 0.5 nil
+                          #'magnus-codex--finish-stop instance buffer nil))
+      (magnus-codex--finish-stop instance buffer force))))
 
 (defun magnus-codex-running-p (instance)
-  "Return non-nil when Codex INSTANCE has a live interactive TUI."
+  "Return non-nil when Codex INSTANCE has a live native TUI."
   (and (magnus-codex--tui-process instance) t))
 
 (defun magnus-codex-switch-to (instance)
   "Switch to Codex INSTANCE, resuming its TUI when necessary."
-  (if (magnus-codex-running-p instance)
-      (pop-to-buffer (magnus-instance-buffer instance))
-    (puthash (magnus-instance-id instance) t magnus-codex--show-on-ready)
-    (unless (magnus-codex--connection instance)
-      (magnus-codex-start instance))
-    (message "Magnus: starting Codex TUI for %s..."
-             (magnus-instance-name instance))))
-
-(defun magnus-codex-answer-approval ()
-  "Answer a fallback observer approval in the current Codex TUI.
-Normal interactive approvals are owned and rendered by the TUI itself."
-  (interactive)
-  (unless magnus-codex--instance
-    (user-error "This is not a Magnus Codex buffer"))
-  (let* ((process (magnus-codex--connection magnus-codex--instance))
-         (table (and process (magnus-codex--approval-table process)))
-         requests)
-    (when table
-      (maphash
-       (lambda (request-id entry)
-         (push (cons (format "%s: %s" request-id
-                             (plist-get entry :method))
-                     request-id)
-               requests))
-       table))
-    (unless requests
-      (user-error "This Codex instance has no pending approvals"))
-    (let* ((label (if (= (length requests) 1)
-                      (caar requests)
-                    (completing-read "Approval: " requests nil t)))
-           (request-id (cdr (assoc label requests)))
-           (entry (gethash request-id table)))
-      (when (equal (plist-get entry :method) "item/permissions/requestApproval")
-        (user-error "Permission-profile approvals require a custom approval handler"))
-      (magnus-codex-respond-approval
-       magnus-codex--instance request-id
-       (completing-read
-        "Decision: "
-        '("accept" "acceptForSession" "decline" "cancel") nil t)
-       (plist-get entry :token)))))
+  (unless (magnus-codex-running-p instance)
+    (magnus-codex-start instance))
+  (pop-to-buffer (magnus-instance-buffer instance)))
 
 (magnus-provider-register
  'codex
  '((start . magnus-codex-start)
    (resume . magnus-codex-start)
    (send . magnus-codex-send)
-   (steer . magnus-codex-steer)
    (interrupt . magnus-codex-interrupt)
    (stop . magnus-codex-stop)
    (running-p . magnus-codex-running-p)

--- a/magnus-provider.el
+++ b/magnus-provider.el
@@ -1,0 +1,54 @@
+;;; magnus-provider.el --- Agent provider dispatch for Magnus -*- lexical-binding: t -*-
+
+;; Copyright (C) 2026 Hrishikesh S
+;; Author: Hrishikesh S <hrish2006@gmail.com>
+;; Version: 0.1.0
+;; URL: https://github.com/hrishikeshs/magnus
+;; SPDX-License-Identifier: MIT
+
+;;; Commentary:
+
+;; Small, additive dispatch layer for non-Claude providers.  Claude Code is
+;; intentionally not registered here: its established vterm implementation in
+;; `magnus-process.el' remains the default and fallback path.
+
+;;; Code:
+
+(require 'magnus-instances)
+
+(defvar magnus-provider--registry (make-hash-table :test #'eq)
+  "Provider symbol to operation alist registry.")
+
+(defun magnus-provider-register (provider operations)
+  "Register PROVIDER with operation alist OPERATIONS.
+Each entry has the form (OPERATION . FUNCTION)."
+  (puthash provider operations magnus-provider--registry))
+
+(defun magnus-provider--load (provider)
+  "Load PROVIDER's optional implementation when available."
+  (unless (or (eq provider 'claude)
+              (gethash provider magnus-provider--registry))
+    (require (intern (format "magnus-provider-%s" provider)) nil t)))
+
+(defun magnus-provider-external-p (instance)
+  "Return non-nil when INSTANCE names a non-Claude provider.
+Unknown providers remain external so they fail clearly instead of silently
+falling back to the legacy Claude process path."
+  (let ((provider (or (magnus-instance-provider instance) 'claude)))
+    (magnus-provider--load provider)
+    (not (eq provider 'claude))))
+
+(defun magnus-provider-call (instance operation &rest arguments)
+  "Call INSTANCE provider's OPERATION with ARGUMENTS.
+INSTANCE is prepended to ARGUMENTS.  Signal `user-error' when the provider
+does not implement OPERATION."
+  (let* ((provider (or (magnus-instance-provider instance) 'claude))
+         (_loaded (magnus-provider--load provider))
+         (operations (gethash provider magnus-provider--registry))
+         (function (alist-get operation operations)))
+    (unless function
+      (user-error "Provider `%s' does not support `%s'" provider operation))
+    (apply function instance arguments)))
+
+(provide 'magnus-provider)
+;;; magnus-provider.el ends here

--- a/magnus-provider.el
+++ b/magnus-provider.el
@@ -50,5 +50,13 @@ does not implement OPERATION."
       (user-error "Provider `%s' does not support `%s'" provider operation))
     (apply function instance arguments)))
 
+(defun magnus-provider-operation-p (instance operation)
+  "Return non-nil when INSTANCE's provider implements OPERATION."
+  (let* ((provider (or (magnus-instance-provider instance) 'claude))
+         (_loaded (magnus-provider--load provider)))
+    (and (alist-get operation
+                    (gethash provider magnus-provider--registry))
+         t)))
+
 (provide 'magnus-provider)
 ;;; magnus-provider.el ends here

--- a/magnus-status.el
+++ b/magnus-status.el
@@ -209,6 +209,7 @@
   "Insert a line for INSTANCE."
   (let* ((name (magnus-instance-name instance))
          (directory (magnus-instance-directory instance))
+         (provider (or (magnus-instance-provider instance) 'claude))
          (status (magnus-instance-status instance))
          (suspended (eq status 'suspended))
          (finished (eq status 'finished))
@@ -229,6 +230,10 @@
          (age (magnus-status--format-age (magnus-instance-created-at instance))))
     (insert "  ")
     (insert (propertize name 'face 'magnus-status-instance-name))
+    (unless (eq provider 'claude)
+      (insert " ")
+      (insert (propertize (format "[%s]" provider)
+                          'face 'font-lock-type-face)))
     (insert " ")
     (insert (propertize (format "[%s]" status-str) 'face status-face))
     (when (magnus-coord-agent-busy-p instance)

--- a/magnus-trace.el
+++ b/magnus-trace.el
@@ -9,14 +9,14 @@
 
 ;;; Commentary:
 
-;; This module provides a JSONL session viewer for Claude Code thinking
-;; traces.  It reads the session JSONL files that Claude Code writes and
-;; renders user messages, thinking blocks, and assistant responses in a
-;; scrollable Emacs buffer with auto-refresh.
+;; This module provides a provider-aware JSONL session viewer.  Providers
+;; locate and normalize their records; this shared UI renders user messages,
+;; thinking blocks, and assistant responses with pagination and auto-refresh.
 
 ;;; Code:
 
 (require 'magnus-instances)
+(require 'magnus-provider)
 
 (declare-function magnus-process--list-sessions "magnus-process")
 (declare-function magnus-process--most-recent-session "magnus-process")
@@ -78,13 +78,19 @@ Beyond this limit, users should use grep or less on the raw JSONL file."
 (defvar-local magnus-trace--jsonl-file nil
   "Path to the JSONL file for this trace buffer.")
 
+(defvar-local magnus-trace--session-id nil
+  "Provider session ID associated with `magnus-trace--jsonl-file'.")
+
+(defvar-local magnus-trace--pending-text ""
+  "Incomplete trailing JSONL text retained for the next refresh.")
+
 (defvar magnus-trace--timer nil
   "Timer for auto-refreshing trace buffers.")
 
 ;;; Major mode
 
 (define-derived-mode magnus-trace-mode special-mode "Trace"
-  "Major mode for viewing Claude Code thinking trace.
+  "Major mode for viewing an agent's thinking trace.
 \\{magnus-trace-mode-map}"
   :group 'magnus
   (setq-local truncate-lines nil)
@@ -102,6 +108,21 @@ Beyond this limit, users should use grep or less on the raw JSONL file."
 
 ;;; Core functions
 
+(defun magnus-trace--reset-read-state (&optional clear-buffer)
+  "Reset JSONL reader state.
+When CLEAR-BUFFER is non-nil, also erase rendered content and overlays."
+  (setq magnus-trace--last-line-count 0
+        magnus-trace--rendered-count 0
+        magnus-trace--file-offset 0
+        magnus-trace--skip-count 0
+        magnus-trace--jsonl-file nil
+        magnus-trace--session-id nil
+        magnus-trace--pending-text "")
+  (when clear-buffer
+    (let ((inhibit-read-only t))
+      (erase-buffer)
+      (remove-overlays))))
+
 (defun magnus-trace-open (instance)
   "Open the trace buffer for INSTANCE showing thinking and messages."
   (let* ((name (magnus-instance-name instance))
@@ -111,13 +132,7 @@ Beyond this limit, users should use grep or less on the raw JSONL file."
       (unless (derived-mode-p 'magnus-trace-mode)
         (magnus-trace-mode))
       (setq magnus-trace--instance instance)
-      (setq magnus-trace--last-line-count 0)
-      (setq magnus-trace--rendered-count 0)
-      (setq magnus-trace--file-offset 0)
-      (setq magnus-trace--skip-count 0)
-      (setq magnus-trace--jsonl-file nil)
-      (let ((inhibit-read-only t))
-        (erase-buffer))
+      (magnus-trace--reset-read-state t)
       (magnus-trace-refresh))
     (magnus-trace--ensure-timer)
     ;; Close any existing trace window before displaying the new one,
@@ -139,9 +154,11 @@ Beyond this limit, users should use grep or less on the raw JSONL file."
   (when magnus-trace--instance
     (let* ((instance magnus-trace--instance)
            (session-id (magnus-instance-session-id instance))
-           (directory (magnus-instance-directory instance)))
-      ;; Try to detect session-id if missing
-      (unless session-id
+           (directory (magnus-instance-directory instance))
+           (external (magnus-provider-external-p instance)))
+      ;; Claude predates providers and discovers its session asynchronously.
+      ;; Never run that heuristic for another provider in the same directory.
+      (unless (or session-id external)
         (let ((sessions (magnus-process--list-sessions directory)))
           (when sessions
             (setq session-id (if (= 1 (length sessions))
@@ -154,10 +171,23 @@ Beyond this limit, users should use grep or less on the raw JSONL file."
               (let ((inhibit-read-only t))
                 (erase-buffer)
                 (setq magnus-trace--last-line-count 0))))))
-      (let ((jsonl-file (when session-id
-                          (magnus-process--session-jsonl-path directory session-id))))
+      (let ((jsonl-file
+             (when session-id
+               (if (and (equal session-id magnus-trace--session-id)
+                        magnus-trace--jsonl-file
+                        (file-exists-p magnus-trace--jsonl-file))
+                   magnus-trace--jsonl-file
+                 (if external
+                     (magnus-provider-call instance 'trace-file)
+                   (magnus-process--session-jsonl-path
+                    directory session-id))))))
         (if (and jsonl-file (file-exists-p jsonl-file))
-            (magnus-trace--append-new-entries jsonl-file)
+            (progn
+              (unless (and (equal jsonl-file magnus-trace--jsonl-file)
+                           (equal session-id magnus-trace--session-id))
+                (magnus-trace--reset-read-state t))
+              (setq magnus-trace--session-id session-id)
+              (magnus-trace--append-new-entries jsonl-file))
           (let ((inhibit-read-only t))
             (goto-char (point-max))
             (unless (> (buffer-size) 0)
@@ -191,7 +221,8 @@ at the top.  Stops when all entries are loaded or the buffer exceeds
              magnus-trace-max-buffer-lines
              (abbreviate-file-name magnus-trace--jsonl-file)))
    (t
-    (let* ((all-lines (magnus-trace--read-lines magnus-trace--jsonl-file 0))
+    (let* ((all-lines (magnus-trace--read-snapshot-lines
+                       magnus-trace--jsonl-file))
            (batch-size (or magnus-trace-max-initial-entries 200))
            (new-skip (max 0 (- magnus-trace--skip-count batch-size)))
            (batch (seq-subseq all-lines new-skip magnus-trace--skip-count))
@@ -213,13 +244,9 @@ at the top.  Stops when all entries are loaded or the buffer exceeds
                    'face 'magnus-trace-separator
                    'magnus-trace-header t)))
         ;; Render batch entries at point (before existing content)
-        (catch 'partial-line
-          (dolist (line batch)
-            (condition-case nil
-                (let ((entry (json-parse-string line :object-type 'alist)))
-                  (magnus-trace--render-entry entry)
-                  (setq parsed-count (1+ parsed-count)))
-              (error (throw 'partial-line nil))))))
+        (dolist (line batch)
+          (when (magnus-trace--render-json-line line)
+            (setq parsed-count (1+ parsed-count)))))
       (setq magnus-trace--skip-count new-skip
             magnus-trace--rendered-count
             (+ magnus-trace--rendered-count parsed-count))
@@ -296,6 +323,12 @@ at the top.  Stops when all entries are loaded or the buffer exceeds
 
 ;;; Content parsing
 
+(defun magnus-trace--marker-match (regexp text start)
+  "Return REGEXP's (START . END) match in TEXT at or after START."
+  (save-match-data
+    (when (string-match regexp text start)
+      (cons (match-beginning 0) (match-end 0)))))
+
 (defun magnus-trace-parse-content (text)
   "Parse TEXT for thinking/response markers.
 Finds [thinking]...[end-thinking] and [response]...[end-response]
@@ -305,44 +338,58 @@ is `thinking' or `response'.  Unmarked text is treated as response."
         (pos 0)
         (len (length text)))
     (while (< pos len)
-      (let ((think-start (string-match "\\[thinking\\]\n?" text pos))
-            (resp-start (string-match "\\[response\\]\n?" text pos)))
+      (let* ((think-match
+              (magnus-trace--marker-match "\\[thinking\\]\n?" text pos))
+             (response-match
+              (magnus-trace--marker-match "\\[response\\]\n?" text pos))
+             (think-start (car-safe think-match))
+             (response-start (car-safe response-match)))
         (cond
          ;; Thinking block comes first (or is only one)
-         ((and think-start (or (null resp-start) (<= think-start resp-start)))
+         ((and think-start
+               (or (null response-start) (<= think-start response-start)))
           ;; Capture any text before the marker as response
           (when (> think-start pos)
             (let ((pre (string-trim (substring text pos think-start))))
               (when (not (string-empty-p pre))
                 (push (list :type 'response :text pre) segments))))
-          (let* ((content-start (match-end 0))
-                 (think-end (string-match "\\[end-thinking\\]\n?" text content-start)))
-            (if think-end
+          (let* ((content-start (cdr think-match))
+                 (end-match
+                  (magnus-trace--marker-match
+                   "\\[end-thinking\\]\n?" text content-start)))
+            (if end-match
                 (progn
-                  (let ((content (string-trim (substring text content-start think-end))))
+                  (let ((content
+                         (string-trim
+                          (substring text content-start (car end-match)))))
                     (when (not (string-empty-p content))
                       (push (list :type 'thinking :text content) segments)))
-                  (setq pos (match-end 0)))
+                  (setq pos (cdr end-match)))
               ;; No end marker — rest is thinking
               (let ((content (string-trim (substring text content-start))))
                 (when (not (string-empty-p content))
                   (push (list :type 'thinking :text content) segments)))
               (setq pos len))))
          ;; Response block comes first (or is only one)
-         ((and resp-start (or (null think-start) (< resp-start think-start)))
+         ((and response-start
+               (or (null think-start) (< response-start think-start)))
           ;; Capture any text before the marker as response
-          (when (> resp-start pos)
-            (let ((pre (string-trim (substring text pos resp-start))))
+          (when (> response-start pos)
+            (let ((pre (string-trim (substring text pos response-start))))
               (when (not (string-empty-p pre))
                 (push (list :type 'response :text pre) segments))))
-          (let* ((content-start (match-end 0))
-                 (resp-end (string-match "\\[end-response\\]\n?" text content-start)))
-            (if resp-end
+          (let* ((content-start (cdr response-match))
+                 (end-match
+                  (magnus-trace--marker-match
+                   "\\[end-response\\]\n?" text content-start)))
+            (if end-match
                 (progn
-                  (let ((content (string-trim (substring text content-start resp-end))))
+                  (let ((content
+                         (string-trim
+                          (substring text content-start (car end-match)))))
                     (when (not (string-empty-p content))
                       (push (list :type 'response :text content) segments)))
-                  (setq pos (match-end 0)))
+                  (setq pos (cdr end-match)))
               ;; No end marker — rest is response
               (let ((content (string-trim (substring text content-start))))
                 (when (not (string-empty-p content))
@@ -362,18 +409,97 @@ is `thinking' or `response'.  Unmarked text is treated as response."
 
 ;;; Internal helpers
 
+(defun magnus-trace--complete-json-p (text)
+  "Return non-nil when TEXT is one complete JSON value."
+  (condition-case nil
+      (progn
+        (ignore (json-parse-string text :object-type 'alist))
+        t)
+    (error
+     ;; A writer may not have finished the final JSONL record yet.
+     nil)))
+
+(defun magnus-trace--split-complete-lines (text)
+  "Split JSONL TEXT into complete lines and an incomplete trailing fragment.
+Return a cons whose car is the line list and whose cdr is the fragment.  A
+valid final JSON value is complete even when no newline has been written yet."
+  (let ((position 0)
+        lines)
+    (while (string-match "\n" text position)
+      (let ((line (substring text position (match-beginning 0))))
+        (unless (string-empty-p line)
+          (push line lines)))
+      (setq position (match-end 0)))
+    (let ((fragment (substring text position)))
+      (if (or (string-empty-p fragment)
+              (magnus-trace--complete-json-p fragment))
+          (progn
+            (unless (string-empty-p fragment)
+              (push fragment lines))
+            (cons (nreverse lines) ""))
+        (cons (nreverse lines) fragment)))))
+
+(defun magnus-trace--read-range (file start end)
+  "Read FILE bytes from START through measured END."
+  (with-temp-buffer
+    (insert-file-contents file nil start end)
+    (buffer-string)))
+
+(defun magnus-trace--read-snapshot (file)
+  "Return complete lines, trailing fragment, and size from one FILE snapshot."
+  (let* ((size (file-attribute-size (file-attributes file)))
+         (text (magnus-trace--read-range file 0 size))
+         (split (magnus-trace--split-complete-lines text)))
+    (list (car split) (cdr split) size)))
+
+(defun magnus-trace--read-snapshot-lines (file)
+  "Return complete JSONL lines from one bounded snapshot of FILE."
+  (car (magnus-trace--read-snapshot file)))
+
+(defun magnus-trace--normalize-entry (entry)
+  "Normalize provider JSONL ENTRY for the shared renderer, or return nil."
+  (let ((instance magnus-trace--instance))
+    (if (and instance
+             (magnus-provider-external-p instance)
+             (magnus-provider-operation-p instance 'trace-entry))
+        (magnus-provider-call instance 'trace-entry entry)
+      entry)))
+
+(defun magnus-trace--render-json-line (line)
+  "Parse and render one provider JSONL LINE.
+Return non-nil when LINE parsed, even when the provider ignores its record."
+  (condition-case err
+      (let* ((entry (json-parse-string line :object-type 'alist))
+             (normalized (magnus-trace--normalize-entry entry)))
+        (when normalized
+          (magnus-trace--render-entry normalized))
+        t)
+    (error
+     (message "Magnus: skipped malformed trace record: %s"
+              (error-message-string err))
+     nil)))
+
 (defun magnus-trace--append-new-entries (jsonl-file)
   "Append new entries from JSONL-FILE to the current trace buffer.
 On initial load, reads the full file but only renders the last
 `magnus-trace-max-initial-entries' entries.  On subsequent refreshes,
 reads only new bytes from the file offset."
-  (setq magnus-trace--jsonl-file jsonl-file)
   (let* ((file-size (file-attribute-size (file-attributes jsonl-file)))
          (at-end (eobp)))
+    (when (and magnus-trace--jsonl-file
+               (or (not (equal jsonl-file magnus-trace--jsonl-file))
+                   (< file-size magnus-trace--file-offset)))
+      (let ((session-id magnus-trace--session-id))
+        (magnus-trace--reset-read-state t)
+        (setq magnus-trace--session-id session-id)))
+    (setq magnus-trace--jsonl-file jsonl-file)
     (cond
      ;; Initial load: read full file, cap to last N entries
      ((zerop magnus-trace--file-offset)
-      (let* ((all-lines (magnus-trace--read-lines jsonl-file 0))
+      (let* ((snapshot (magnus-trace--read-range
+                        jsonl-file 0 file-size))
+             (split (magnus-trace--split-complete-lines snapshot))
+             (all-lines (car split))
              (total (length all-lines))
              (skip (if (and magnus-trace-max-initial-entries
                             (> total magnus-trace-max-initial-entries))
@@ -383,16 +509,21 @@ reads only new bytes from the file offset."
         (when lines-to-render
           (magnus-trace--render-lines lines-to-render skip))
         (setq magnus-trace--file-offset file-size
+              magnus-trace--pending-text (cdr split)
               magnus-trace--last-line-count total
               magnus-trace--skip-count skip)))
      ;; Incremental: read only new bytes
      ((> file-size magnus-trace--file-offset)
-      (let* ((new-text (magnus-trace--read-tail jsonl-file
-                                                magnus-trace--file-offset))
-             (new-lines (split-string new-text "\n" t)))
+      (let* ((new-text
+              (magnus-trace--read-range
+               jsonl-file magnus-trace--file-offset file-size))
+             (split (magnus-trace--split-complete-lines
+                     (concat magnus-trace--pending-text new-text)))
+             (new-lines (car split)))
         (when new-lines
           (magnus-trace--render-lines new-lines 0))
         (setq magnus-trace--file-offset file-size
+              magnus-trace--pending-text (cdr split)
               magnus-trace--last-line-count
               (+ magnus-trace--last-line-count (length new-lines))))))
     ;; Trim buffer if it has grown too large (2x cap)
@@ -420,19 +551,18 @@ SKIP is the number of earlier entries omitted (for the header)."
                          skip)
                  'face 'magnus-trace-separator
                  'magnus-trace-header t)))
-      (catch 'partial-line
-        (dolist (line lines)
-          (condition-case nil
-              (let ((entry (json-parse-string line :object-type 'alist)))
-                (magnus-trace--render-entry entry)
-                (setq parsed-count (1+ parsed-count)))
-            (error (throw 'partial-line nil))))))
+      (dolist (line lines)
+        (when (magnus-trace--render-json-line line)
+          (setq parsed-count (1+ parsed-count)))))
     (setq magnus-trace--rendered-count
           (+ magnus-trace--rendered-count parsed-count))))
 
 (defun magnus-trace--trim (jsonl-file)
   "Trim the current trace buffer to last N entries from JSONL-FILE."
-  (let* ((all-lines (magnus-trace--read-lines jsonl-file 0))
+  (let* ((snapshot (magnus-trace--read-snapshot jsonl-file))
+         (all-lines (nth 0 snapshot))
+         (pending (nth 1 snapshot))
+         (snapshot-size (nth 2 snapshot))
          (total (length all-lines))
          (keep magnus-trace-max-initial-entries)
          (skip (max 0 (- total keep)))
@@ -445,20 +575,8 @@ SKIP is the number of earlier entries omitted (for the header)."
       (magnus-trace--render-lines lines-to-render skip))
     (setq magnus-trace--last-line-count total
           magnus-trace--skip-count skip
-          magnus-trace--file-offset
-          (file-attribute-size (file-attributes jsonl-file)))))
-
-(defun magnus-trace--read-lines (file offset)
-  "Read all lines from FILE starting at byte OFFSET."
-  (with-temp-buffer
-    (insert-file-contents file nil offset)
-    (split-string (buffer-string) "\n" t)))
-
-(defun magnus-trace--read-tail (file offset)
-  "Read new bytes from FILE starting at byte OFFSET."
-  (with-temp-buffer
-    (insert-file-contents file nil offset)
-    (buffer-string)))
+          magnus-trace--file-offset snapshot-size
+          magnus-trace--pending-text pending)))
 
 (defun magnus-trace--render-entry (entry)
   "Render a JSONL ENTRY into the trace buffer."

--- a/magnus-trace.el
+++ b/magnus-trace.el
@@ -173,12 +173,14 @@ When CLEAR-BUFFER is non-nil, also erase rendered content and overlays."
                 (setq magnus-trace--last-line-count 0))))))
       (let ((jsonl-file
              (when session-id
-               (if (and (equal session-id magnus-trace--session-id)
-                        magnus-trace--jsonl-file
-                        (file-exists-p magnus-trace--jsonl-file))
-                   magnus-trace--jsonl-file
-                 (if external
-                     (magnus-provider-call instance 'trace-file)
+               (if external
+                   ;; External providers may rotate files while preserving a
+                   ;; stable session ID, so let the provider resolve each time.
+                   (magnus-provider-call instance 'trace-file)
+                 (if (and (equal session-id magnus-trace--session-id)
+                          magnus-trace--jsonl-file
+                          (file-exists-p magnus-trace--jsonl-file))
+                     magnus-trace--jsonl-file
                    (magnus-process--session-jsonl-path
                     directory session-id))))))
         (if (and jsonl-file (file-exists-p jsonl-file))

--- a/magnus.el
+++ b/magnus.el
@@ -157,6 +157,9 @@ Takes the working directory as argument and returns a string."
 (defvar magnus--initialized nil
   "Non-nil if magnus has been initialized.")
 
+(defvar magnus--restart-required nil
+  "Non-nil after an in-session Magnus reinstall requires an Emacs restart.")
+
 (defvar magnus--agents-index nil
   "In-memory agent expertise index.
 Alist of (DIRECTORY . ((NAME . TAGS-STRING) ...)).")
@@ -520,6 +523,9 @@ them now; new agents populate once their memory file exists."
 
 (defun magnus--ensure-initialized ()
   "Ensure magnus is initialized."
+  (when magnus--restart-required
+    (user-error
+     "Magnus was upgraded in this Emacs session; restart Emacs before use"))
   (unless magnus--initialized
     (require 'magnus-instances)
     (require 'magnus-persistence)
@@ -597,7 +603,9 @@ The agent runs to completion and exits."
   (setq magnus--initialized nil))
 
 (defun magnus--upgrade-execute ()
-  "Archive all agents, save state, and reinstall Magnus."
+  "Archive all agents, save state, and reinstall Magnus.
+The user must restart Emacs afterward so loaded struct and function definitions
+cannot be mixed across package versions."
   (let ((active (magnus-instances-active-list)))
     (when active
       (dolist (instance active)
@@ -608,13 +616,16 @@ The agent runs to completion and exits."
   (magnus-persistence-save)
   (magnus--shutdown)
   (package-reinstall 'magnus)
-  (message "Magnus upgraded. Run M-x magnus to resurrect your agents."))
+  (setq magnus--restart-required t)
+  (message
+   "Magnus upgraded. Restart Emacs, then run M-x magnus to resurrect agents."))
 
 ;;;###autoload
 (defun magnus-upgrade ()
   "Upgrade Magnus gracefully.
 Warns active agents, gives them 120 seconds to save their work,
-archives them, saves state, and reinstalls the package."
+archives them, saves state, and reinstalls the package.  Restart Emacs after
+the reinstall so live data structures are not mixed across package versions."
   (interactive)
   (magnus--ensure-initialized)
   (let ((active (magnus-instances-active-list)))
@@ -624,7 +635,8 @@ archives them, saves state, and reinstalls the package."
           (magnus-persistence-save)
           (magnus--shutdown)
           (package-reinstall 'magnus)
-          (message "Magnus upgraded. Run M-x magnus to start."))
+          (setq magnus--restart-required t)
+          (message "Magnus upgraded. Restart Emacs, then run M-x magnus."))
       ;; Warn agents
       (dolist (instance active)
         (magnus-coord-nudge-agent

--- a/magnus.el
+++ b/magnus.el
@@ -57,6 +57,7 @@
 (declare-function magnus-coord-ensure-watchers "magnus-coord")
 (declare-function magnus-status "magnus-status")
 (declare-function magnus-process-create "magnus-process")
+(declare-function magnus-process-create-codex "magnus-process")
 (declare-function magnus-instances-list "magnus-instances")
 (declare-function magnus-instance-name "magnus-instances")
 (declare-function magnus-instance-directory "magnus-instances")
@@ -557,6 +558,18 @@ NAME is the instance name.  If nil, auto-generates one."
   (interactive)
   (magnus--ensure-initialized)
   (magnus-process-create directory name))
+
+;;;###autoload
+(defun magnus-create-codex (&optional directory name initial-message)
+  "Create an opt-in Codex instance managed through App Server.
+DIRECTORY and NAME have the same meaning as in `magnus-create-instance'.
+When INITIAL-MESSAGE is non-nil, start the first turn after connecting."
+  (interactive
+   (list nil nil
+         (let ((message (read-string "Initial Codex task (RET to skip): ")))
+           (unless (string-empty-p message) message))))
+  (magnus--ensure-initialized)
+  (magnus-process-create-codex directory name initial-message))
 
 ;;;###autoload
 (defun magnus-create-headless (prompt &optional directory name)

--- a/magnus.el
+++ b/magnus.el
@@ -568,9 +568,9 @@ NAME is the instance name.  If nil, auto-generates one."
 
 ;;;###autoload
 (defun magnus-create-codex (&optional directory name initial-message)
-  "Create an opt-in Codex instance managed through App Server.
+  "Create an opt-in Codex instance in its native TUI.
 DIRECTORY and NAME have the same meaning as in `magnus-create-instance'.
-When INITIAL-MESSAGE is non-nil, start the first turn after connecting."
+When INITIAL-MESSAGE is non-nil, include it in the first turn."
   (interactive
    (list nil nil
          (let ((message (read-string "Initial Codex task (RET to skip): ")))

--- a/magnus.el
+++ b/magnus.el
@@ -49,6 +49,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'magnus-instances)
 
 (declare-function magnus-persistence-load "magnus-persistence")
 (declare-function magnus-persistence--setup-autosave "magnus-persistence")

--- a/test/magnus-provider-tests.el
+++ b/test/magnus-provider-tests.el
@@ -33,11 +33,13 @@
       (kill-buffer (car terminal)))))
 
 (defun magnus-test--write-codex-rollout
-    (root id directory prompt &optional parent-thread-id padding)
+    (root id directory prompt &optional parent-thread-id padding session-id date)
   "Write a test Codex rollout under ROOT for ID, DIRECTORY, and PROMPT.
 PARENT-THREAD-ID marks the record as a subagent when non-nil.
-PADDING adds an unrelated record before the first user message."
-  (let* ((date-directory (expand-file-name "2026/07/11" root))
+PADDING adds an unrelated record before the first user message.
+SESSION-ID defaults to ID; a different value models a resumed rollout.
+DATE defaults to the original deterministic test fixture date."
+  (let* ((date-directory (expand-file-name (or date "2026/07/11") root))
          (file (expand-file-name (format "rollout-test-%s.jsonl" id)
                                  date-directory)))
     (make-directory date-directory t)
@@ -45,7 +47,8 @@ PADDING adds an unrelated record before the first user message."
       (insert
        (json-encode
         `((type . "session_meta")
-          (payload . ((id . ,id) (session_id . ,id)
+          (payload . ((id . ,id)
+                      (session_id . ,(or session-id id))
                       (parent_thread_id . ,parent-thread-id)
                       (cwd . ,directory)))))
        "\n"
@@ -205,7 +208,7 @@ PADDING adds an unrelated record before the first user message."
   (let* ((home (make-temp-file "magnus-codex-home-" t))
          (other-home (make-temp-file "magnus-codex-other-home-" t))
          (process-environment (copy-sequence process-environment))
-         (magnus-codex--session-file-cache (make-hash-table :test #'equal))
+         (magnus-codex--trace-file-cache (make-hash-table :test #'equal))
          (instance (magnus-instances-create "/tmp" "old-codex" 'codex))
          (session-id "019f-old-session")
          (directory (expand-file-name "sessions/2024/01/02" home))
@@ -231,6 +234,46 @@ PADDING adds an unrelated record before the first user message."
           (should (equal (magnus-codex-trace-file instance) other-file)))
       (delete-directory home t)
       (delete-directory other-home t))))
+
+(ert-deftest magnus-codex-trace-follows-resumed-rollout ()
+  (let* ((home (make-temp-file "magnus-codex-resumed-trace-" t))
+         (sessions-root (expand-file-name "sessions" home))
+         (process-environment (copy-sequence process-environment))
+         (magnus-codex--trace-file-cache (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp/project" "winter-codex"
+                                            'codex))
+         (session-id "019f-stable-thread")
+         root-file continuation-file)
+    (unwind-protect
+        (progn
+          (setenv "CODEX_HOME" home)
+          (setq root-file
+                (magnus-test--write-codex-rollout
+                 sessions-root session-id "/tmp/project" "root turn"
+                 nil nil nil "2024/01/02"))
+          (magnus-instances-update instance :session-id session-id)
+          (with-temp-buffer
+            (magnus-trace-mode)
+            (setq magnus-trace--instance instance)
+            (magnus-trace-refresh)
+            (should (equal magnus-trace--jsonl-file root-file))
+            ;; A resume keeps SESSION-ID in metadata but gives the rollout a
+            ;; new filename ID.  The still-live root cache must not conceal it.
+            (let* ((recent-directory
+                    (car (magnus-codex--session-directories)))
+                   (recent-date
+                    (file-relative-name recent-directory sessions-root)))
+              (setq continuation-file
+                    (magnus-test--write-codex-rollout
+                     sessions-root "019f-continuation" "/tmp/project"
+                     "resumed turn" nil nil session-id recent-date)))
+            (set-file-times continuation-file
+                            (time-add (current-time) (seconds-to-time 5)))
+            (magnus-trace-refresh)
+            (should (equal magnus-trace--jsonl-file continuation-file))
+            (should (string-match-p "resumed turn" (buffer-string)))
+            (should-not (string-match-p "root turn" (buffer-string)))))
+      (delete-directory home t))))
 
 (ert-deftest magnus-codex-trace-normalizes-only-visible-events ()
   (let* ((instance (magnus-instances-create "/tmp" "trace-codex" 'codex))

--- a/test/magnus-provider-tests.el
+++ b/test/magnus-provider-tests.el
@@ -2,28 +2,13 @@
 
 (require 'ert)
 (require 'cl-lib)
+(require 'json)
 (require 'magnus)
 (require 'magnus-instances)
 (require 'magnus-provider)
 (require 'magnus-provider-codex)
 (require 'magnus-coord)
 (require 'magnus-health)
-
-(defun magnus-test--codex-process (instance)
-  "Create a live inert App Server stand-in for INSTANCE."
-  (let ((process
-         (make-pipe-process
-          :name (generate-new-buffer-name
-                 (format "magnus-test-%s" (magnus-instance-id instance)))
-          :noquery t)))
-    (process-put process 'magnus-codex-instance instance)
-    (process-put process 'magnus-codex-pending
-                 (make-hash-table :test #'equal))
-    (process-put process 'magnus-codex-approvals
-                 (make-hash-table :test #'equal))
-    (process-put process 'magnus-codex-turn-starting nil)
-    (magnus-codex--register-connection instance process)
-    process))
 
 (defun magnus-test--codex-tui (instance)
   "Create a live terminal-process stand-in for INSTANCE."
@@ -34,24 +19,48 @@
                    :name (generate-new-buffer-name "magnus-test-tui")
                    :buffer buffer
                    :noquery t)))
+    (process-put process 'magnus-codex-instance instance)
     (magnus-instances-update instance :buffer buffer :status 'running)
     (cons buffer process)))
 
-(defun magnus-test--server-websocket-frame (text)
-  "Encode TEXT as an unmasked, final server WebSocket text frame."
-  (let* ((payload (encode-coding-string text 'utf-8))
-         (length (length payload)))
-    (concat
-     (cond
-      ((< length 126)
-       (magnus-codex--byte-string 129 length))
-      ((< length 65536)
-       (concat (magnus-codex--byte-string 129 126)
-               (magnus-codex--integer-bytes length 2)))
-      (t
-       (concat (magnus-codex--byte-string 129 127)
-               (magnus-codex--integer-bytes length 8))))
-     payload)))
+(defun magnus-test--delete-terminal (terminal)
+  "Delete TERMINAL's process and buffer."
+  (when terminal
+    (when (process-live-p (cdr terminal))
+      (delete-process (cdr terminal)))
+    (when (buffer-live-p (car terminal))
+      (kill-buffer (car terminal)))))
+
+(defun magnus-test--write-codex-rollout
+    (root id directory prompt &optional parent-thread-id padding)
+  "Write a test Codex rollout under ROOT for ID, DIRECTORY, and PROMPT.
+PARENT-THREAD-ID marks the record as a subagent when non-nil.
+PADDING adds an unrelated record before the first user message."
+  (let* ((date-directory (expand-file-name "2026/07/11" root))
+         (file (expand-file-name (format "rollout-test-%s.jsonl" id)
+                                 date-directory)))
+    (make-directory date-directory t)
+    (with-temp-file file
+      (insert
+       (json-encode
+        `((type . "session_meta")
+          (payload . ((id . ,id) (session_id . ,id)
+                      (parent_thread_id . ,parent-thread-id)
+                      (cwd . ,directory)))))
+       "\n"
+       (json-encode
+        '((type . "event_msg") (payload . ((type . "task_started")))))
+       "\n"
+       (if padding
+           (concat (json-encode `((type . "response_item")
+                                  (payload . ((text . ,padding)))))
+                   "\n")
+         "")
+       (json-encode
+        `((type . "event_msg")
+          (payload . ((type . "user_message") (message . ,prompt)))))
+       "\n"))
+    file))
 
 (ert-deftest magnus-provider-legacy-state-defaults-to-claude ()
   (let ((instance (magnus-instances-deserialize
@@ -77,67 +86,17 @@
     (should (magnus-provider-external-p instance))
     (should-error (magnus-provider-call instance 'start) :type 'user-error)))
 
-(ert-deftest magnus-codex-parses-current-app-server-events ()
-  (let ((message
-         (magnus-codex--parse-line
-          "{\"jsonrpc\":\"2.0\",\"method\":\"item/agentMessage/delta\",\"params\":{\"delta\":\"hi\"}}")))
-    (should (equal (alist-get 'method message) "item/agentMessage/delta"))
-    (should (equal (alist-get 'delta (alist-get 'params message)) "hi")))
-  (should (equal (magnus-codex--input "hello")
-                 '[((type . "text") (text . "hello"))]))
-  (should (equal (magnus-codex--thread-status-name
-                  '((type . "active") (activeFlags . [])))
-                 "active"))
+(ert-deftest magnus-codex-onboarding-keeps-identity-and-journal ()
   (let* ((instance (magnus-instances-create "/tmp" "solar-fox" 'codex))
-         (instructions (magnus-codex--instructions instance)))
-    (should (string-match-p "solar-fox" instructions))
-    (should (string-match-p "\\[thinking\\]" instructions))
-    (should (string-match-p "visible working notebook" instructions))
-    (should (string-match-p "Discoveries" instructions))
-    (should (string-match-p "future-you" instructions))))
-
-(ert-deftest magnus-codex-parses-split-extended-websocket-frame ()
-  (let* ((instance (magnus-instances-create "/tmp" "framed-codex" 'codex))
-         (process (magnus-test--codex-process instance))
-         (padding (make-string 180 ?x))
-         (frame (magnus-test--server-websocket-frame
-                 (magnus-codex--json
-                  `((id . 1) (result . ((padding . ,padding)))))))
-         result)
-    (unwind-protect
-        (progn
-          (process-put process 'magnus-codex-frame-buffer
-                       (magnus-codex--byte-string))
-          (puthash 1
-                   (lambda (value error)
-                     (should-not error)
-                     (setq result value))
-                   (process-get process 'magnus-codex-pending))
-          (magnus-codex--consume-frames process (substring frame 0 11))
-          (should-not result)
-          (magnus-codex--consume-frames process (substring frame 11))
-          (should (equal (alist-get 'padding result) padding))
-          (should (string-empty-p
-                   (process-get process 'magnus-codex-frame-buffer))))
-      (delete-process process))))
-
-(ert-deftest magnus-codex-validates-websocket-upgrade-accept ()
-  (let* ((instance (magnus-instances-create "/tmp" "upgrade-codex" 'codex))
-         (process (magnus-test--codex-process instance)))
-    (unwind-protect
-        (progn
-          (process-put process 'magnus-codex-websocket-key
-                       "dGhlIHNhbXBsZSBub25jZQ==")
-          (should (equal (magnus-codex--websocket-accept process)
-                         "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=")))
-      (delete-process process))))
-
-(ert-deftest magnus-codex-client-websocket-frames-are-unibyte ()
-  (let ((frame (magnus-codex--websocket-frame
-                "A deliberately ASCII JSON payload long enough to mask")))
-    (should-not (multibyte-string-p frame))
-    (should (= (aref frame 0) 129))
-    (should-not (zerop (logand (aref frame 1) 128)))))
+         (prompt (magnus-codex--onboarding-prompt
+                  instance "Fix the parser" "marker-1")))
+    (should (string-match-p "You are solar-fox" prompt))
+    (should (string-match-p "Fix the parser" prompt))
+    (should (string-match-p "marker-1" prompt))
+    (should (string-match-p "\\[thinking\\]" prompt))
+    (should (string-match-p "visible working notebook" prompt))
+    (should (string-match-p "Discoveries" prompt))
+    (should (string-match-p "future-you" prompt))))
 
 (ert-deftest magnus-codex-onboards-returning-identity-from-memory ()
   (let* ((directory (make-temp-file "magnus-codex-memory-" t))
@@ -160,229 +119,127 @@
                      instructions))))
       (delete-directory directory t))))
 
-(ert-deftest magnus-codex-new-thread-onboarding-is-durable-user-input ()
-  (let* ((instance (magnus-instances-create "/tmp" "named-codex" 'codex))
-         (prompt (magnus-codex--onboarding-prompt instance "Fix the parser")))
-    (should (string-match-p "You are named-codex" prompt))
-    (should (string-match-p "Initial task from the user" prompt))
-    (should (string-match-p "Fix the parser" prompt))
-    (should (string-match-p "\\[thinking\\]" prompt))
-    (magnus-instances-update instance :session-id "observer-owned-thread")
-    (let ((command (magnus-codex--tui-command instance prompt)))
-      (should (string-match-p "exec codex resume" command))
-      (should (string-match-p "observer-owned-thread" command))
-      (should-not (string-match-p "developer_instructions=" command)))))
-
-(ert-deftest magnus-codex-command-approval-keeps-v2-response-shape ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (instance (magnus-instances-create "/tmp" "codex-user" 'codex))
-         (request-id 7)
-         (process (magnus-test--codex-process instance))
-         sent)
-    (unwind-protect
-        (progn
-          (puthash request-id
-                   (list :instance instance :process process
-                         :method "item/commandExecution/requestApproval")
-                   (magnus-codex--approval-table process))
-          (cl-letf (((symbol-function 'magnus-codex--send-object)
-                     (lambda (_process object) (setq sent object)))
-                    ((symbol-function 'magnus-codex--insert)
-                     (lambda (&rest _arguments) nil)))
-            (magnus-codex-respond-approval instance request-id "accept"))
-          (should (equal (alist-get 'result sent)
-                         '((decision . "accept")))))
-      (delete-process process))))
-
-(ert-deftest magnus-codex-command-approval-allows-policy-amendment ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (instance (magnus-instances-create "/tmp" "policy-codex" 'codex))
-         (process (magnus-test--codex-process instance))
-         (decision
-          '((acceptWithExecpolicyAmendment
-             . ((execpolicy_amendment . ("git" "status"))))))
-         sent)
-    (unwind-protect
-        (progn
-          (puthash 12
-                   (list :instance instance :process process
-                         :method "item/commandExecution/requestApproval")
-                   (magnus-codex--approval-table process))
-          (cl-letf (((symbol-function 'magnus-codex--send-object)
-                     (lambda (_process object) (setq sent object)))
-                    ((symbol-function 'magnus-codex--insert)
-                     (lambda (&rest _arguments) nil)))
-            (magnus-codex-respond-approval instance 12 decision))
-          (should (equal (alist-get 'result sent)
-                         `((decision . ,decision)))))
-      (delete-process process))))
-
-(ert-deftest magnus-codex-permission-approval-requires-profile ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (instance (magnus-instances-create "/tmp" "codex-user" 'codex))
-         (request-id 8)
-         (process (magnus-test--codex-process instance)))
-    (unwind-protect
-        (progn
-          (puthash request-id
-                   (list :instance instance :process process
-                         :method "item/permissions/requestApproval")
-                   (magnus-codex--approval-table process))
-          (should-error
-           (magnus-codex-respond-approval instance request-id "accept")
-           :type 'user-error))
-      (delete-process process))))
-
-(ert-deftest magnus-codex-rejects-unknown-command-approval-decision ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (instance (magnus-instances-create "/tmp" "codex-user" 'codex))
-         (request-id 9)
-         (process (magnus-test--codex-process instance)))
-    (unwind-protect
-        (progn
-          (puthash request-id
-                   (list :instance instance :process process
-                         :method "item/fileChange/requestApproval")
-                   (magnus-codex--approval-table process))
-          (should-error
-           (magnus-codex-respond-approval
-            instance request-id "approve-everything")
-           :type 'user-error))
-      (delete-process process))))
-
-(ert-deftest magnus-codex-approval-ids-are-scoped-per-process ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (first (magnus-instances-create "/tmp" "first-codex" 'codex))
-         (second (magnus-instances-create "/tmp" "second-codex" 'codex))
-         (first-process (magnus-test--codex-process first))
-         (second-process (magnus-test--codex-process second))
-         sent)
-    (magnus-instances-update first :session-id "thread-first")
-    (magnus-instances-update second :session-id "thread-second")
-    (unwind-protect
-        (cl-letf (((symbol-function 'magnus-codex--insert)
-                   (lambda (&rest _arguments) nil))
-                  ((symbol-function 'magnus-codex--send-object)
-                   (lambda (process object)
-                     (push (cons process object) sent))))
-          (magnus-codex--handle-server-request
-           first-process 3 "item/commandExecution/requestApproval"
-           '((threadId . "thread-first") (command . "git status")))
-          (magnus-codex--handle-server-request
-           second-process 3 "item/fileChange/requestApproval"
-           '((threadId . "thread-second") (reason . "edit file")))
-          (should (= 1 (hash-table-count
-                        (magnus-codex--approval-table first-process))))
-          (should (= 1 (hash-table-count
-                        (magnus-codex--approval-table second-process))))
-          (magnus-codex-respond-approval first 3 "accept")
-          (should (= 0 (hash-table-count
-                        (magnus-codex--approval-table first-process))))
-          (should (= 1 (hash-table-count
-                        (magnus-codex--approval-table second-process))))
-          (magnus-codex-respond-approval second 3 "decline")
-          (should (= 0 (hash-table-count
-                        (magnus-codex--approval-table second-process))))
-          (should (= 2 (length sent))))
-      (delete-process first-process)
-      (delete-process second-process))))
-
-(ert-deftest magnus-codex-stale-approval-cannot-answer-reused-id ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (magnus-codex--retired-approval-ids
-          (make-hash-table :test #'equal))
-         (instance (magnus-instances-create "/tmp" "reconnected" 'codex))
-         (first-process (magnus-test--codex-process instance))
-         second-process old-token current-token sent)
-    (magnus-instances-update instance :session-id "thread-reconnected")
-    (unwind-protect
-        (cl-letf (((symbol-function 'magnus-codex--insert)
-                   (lambda (&rest _arguments) nil))
-                  ((symbol-function 'magnus-codex--send-object)
-                   (lambda (_process object) (setq sent object))))
-          (magnus-codex--handle-server-request
-           first-process 3 "item/commandExecution/requestApproval"
-           '((threadId . "thread-reconnected") (command . "old")))
-          (setq old-token (magnus-codex-approval-token instance 3))
-          (delete-process first-process)
-          (setq second-process (magnus-test--codex-process instance))
-          (magnus-codex--handle-server-request
-           second-process 3 "item/commandExecution/requestApproval"
-           '((threadId . "thread-reconnected") (command . "new")))
-          (setq current-token (magnus-codex-approval-token instance 3))
-          (should-error
-           (magnus-codex-respond-approval instance 3 "accept")
-           :type 'user-error)
-          (should-error
-           (magnus-codex-respond-approval instance 3 "accept" old-token)
-           :type 'user-error)
-          (magnus-codex-respond-approval
-           instance 3 "accept" current-token)
-          (should (equal (alist-get 'result sent)
-                         '((decision . "accept")))))
-      (when (process-live-p first-process) (delete-process first-process))
-      (when (and second-process (process-live-p second-process))
-        (delete-process second-process)))))
-
-(ert-deftest magnus-codex-approval-summary-accepts-argv-arrays ()
-  (should
-   (equal
-    (magnus-codex--approval-summary
-     '((command . ("git" "status" "--short")) (cwd . "/tmp")))
-    "git status --short\ncwd: /tmp")))
-
-(ert-deftest magnus-codex-tui-command-resumes-managed-thread ()
-  (let* ((magnus-codex-remote "unix://")
-         (instance (magnus-instances-create
-                    "/tmp/project with spaces" "tui-codex" 'codex)))
+(ert-deftest magnus-codex-tui-command-is-standalone-and-resumable ()
+  (let ((instance (magnus-instances-create
+                   "/tmp/project with spaces" "tui-codex" 'codex)))
+    (let ((fresh (magnus-codex--tui-command instance "First prompt")))
+      (should (string-match-p "exec codex" fresh))
+      (should-not (string-match-p "app-server\\|--remote\\|resume" fresh)))
     (magnus-instances-update instance :session-id "thread-1")
-    (let ((command (magnus-codex--tui-command
-                    instance "read this next")))
-      (should (string-match-p "codex resume" command))
-      (should (string-match-p
-               (regexp-quote
-                (format "--remote %s" (shell-quote-argument "unix://")))
-               command))
-      (should (string-match-p "thread-1" command))
+    (let ((resumed (magnus-codex--tui-command instance "read this next")))
+      (should (string-match-p "exec codex resume" resumed))
+      (should (string-match-p "thread-1" resumed))
       (should (string-match-p
                (regexp-quote (shell-quote-argument "read this next"))
-               command)))))
+               resumed)))))
+
+(ert-deftest magnus-codex-session-capture-matches-exact-first-prompt ()
+  (let* ((root (make-temp-file "magnus-codex-sessions-" t))
+         (directory (make-temp-file "magnus-codex-project-" t))
+         (prompt "Unique Magnus onboarding\nmarker:alpha")
+         (file (magnus-test--write-codex-rollout
+                root "session-alpha" directory prompt)))
+    (unwind-protect
+        (should (equal (magnus-codex--session-id-from-file
+                        file directory prompt)
+                       "session-alpha"))
+      (delete-directory root t)
+      (delete-directory directory t))))
+
+(ert-deftest magnus-codex-session-capture-is-concurrent-launch-safe ()
+  (let* ((root (make-temp-file "magnus-codex-sessions-" t))
+         (directory (make-temp-file "magnus-codex-project-" t))
+         (first (magnus-instances-create directory "first-codex" 'codex))
+         (second (magnus-instances-create directory "second-codex" 'codex))
+         (first-file (magnus-test--write-codex-rollout
+                      root "session-first" directory "prompt:first"))
+         (second-file (magnus-test--write-codex-rollout
+                       root "session-second" directory "prompt:second")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'magnus-codex--session-files)
+                   (lambda () (list second-file first-file))))
+          (should (equal (magnus-codex--find-session-id
+                          first "prompt:first" nil)
+                         "session-first"))
+          (should (equal (magnus-codex--find-session-id
+                          second "prompt:second" nil)
+                         "session-second")))
+      (delete-directory root t)
+      (delete-directory directory t))))
+
+(ert-deftest magnus-codex-session-capture-rejects-subagent-rollout ()
+  (let* ((root (make-temp-file "magnus-codex-sessions-" t))
+         (directory (make-temp-file "magnus-codex-project-" t))
+         (prompt "Inherited parent prompt")
+         (file (magnus-test--write-codex-rollout
+                root "session-child" directory prompt "session-parent")))
+    (unwind-protect
+        (should-not
+         (magnus-codex--session-id-from-file file directory prompt))
+      (delete-directory root t)
+      (delete-directory directory t))))
+
+(ert-deftest magnus-codex-session-capture-tolerates-large-preamble ()
+  (let* ((root (make-temp-file "magnus-codex-sessions-" t))
+         (directory (make-temp-file "magnus-codex-project-" t))
+         (prompt "Onboarding after a large preamble")
+         (file (magnus-test--write-codex-rollout
+                root "session-large" directory prompt nil
+                (make-string 150000 ?x))))
+    (unwind-protect
+        (should (equal (magnus-codex--session-id-from-file
+                        file directory prompt)
+                       "session-large"))
+      (delete-directory root t)
+      (delete-directory directory t))))
+
+(ert-deftest magnus-codex-stale-capture-cannot-reassign-replacement ()
+  (let* ((instance (magnus-instances-create "/tmp" "replacement" 'codex))
+         (old-terminal (magnus-test--codex-tui instance))
+         (old-process (cdr old-terminal))
+         (new-terminal (magnus-test--codex-tui instance)))
+    (unwind-protect
+        (progn
+          (process-put old-process 'magnus-codex-capture-prompt "old")
+          (process-put old-process 'magnus-codex-files-before nil)
+          (process-put old-process 'magnus-codex-capture-deadline
+                       (+ (float-time) 30))
+          (cl-letf (((symbol-function 'magnus-codex--find-session-id)
+                     (lambda (&rest _arguments) "stale-session")))
+            (magnus-codex--poll-session old-process))
+          (should-not (magnus-instance-session-id instance))
+          (should (eq (magnus-codex--tui-process instance)
+                      (cdr new-terminal))))
+      (magnus-test--delete-terminal old-terminal)
+      (magnus-test--delete-terminal new-terminal))))
 
 (ert-deftest magnus-codex-messages-use-tui-as-sole-writer ()
-  (let* ((magnus-codex--input-queues (make-hash-table :test #'equal))
-         (magnus-codex--input-busy (make-hash-table :test #'equal))
-         (magnus-codex--input-retry (make-hash-table :test #'equal))
-         (magnus-codex--tui-ready (make-hash-table :test #'equal))
-         (instance (magnus-instances-create "/tmp" "tui-codex" 'codex))
+  (let* ((instance (magnus-instances-create "/tmp" "tui-codex" 'codex))
          (terminal (magnus-test--codex-tui instance))
-         sent return-sent)
-    (puthash (magnus-instance-id instance) t magnus-codex--tui-ready)
+         (process (cdr terminal))
+         sent return-sent timers)
+    (process-put process 'magnus-codex-ready t)
     (unwind-protect
-        (cl-letf (((symbol-function 'magnus-codex--request)
-                  (lambda (&rest _arguments)
-                     (ert-fail "observer attempted an interactive request")))
-                  ((symbol-function 'vterm-send-string)
+        (cl-letf (((symbol-function 'vterm-send-string)
                    (lambda (text &optional _paste-p) (setq sent text)))
                   ((symbol-function 'vterm-send-return)
                    (lambda () (setq return-sent t)))
                   ((symbol-function 'run-with-timer)
                    (lambda (_seconds _repeat function &rest arguments)
-                     (apply function arguments))))
+                     (push (cons function arguments) timers)
+                     'test-timer)))
           (magnus-codex-send instance "read this next")
           (should (equal sent "read this next"))
-          (should return-sent))
-      (delete-process (cdr terminal))
-      (kill-buffer (car terminal)))))
+          (should return-sent)
+          (should-not (process-get process 'magnus-codex-input-queue)))
+      (magnus-test--delete-terminal terminal))))
 
 (ert-deftest magnus-codex-concurrent-tui-messages-are-serialized ()
-  (let* ((magnus-codex--input-queues (make-hash-table :test #'equal))
-         (magnus-codex--input-busy (make-hash-table :test #'equal))
-         (magnus-codex--input-retry (make-hash-table :test #'equal))
-         (magnus-codex--tui-ready (make-hash-table :test #'equal))
-         (instance (magnus-instances-create "/tmp" "queued-codex" 'codex))
+  (let* ((instance (magnus-instances-create "/tmp" "queued-codex" 'codex))
          (terminal (magnus-test--codex-tui instance))
+         (process (cdr terminal))
          timers events)
-    (puthash (magnus-instance-id instance) t magnus-codex--tui-ready)
+    (process-put process 'magnus-codex-ready t)
     (unwind-protect
         (cl-letf (((symbol-function 'vterm-send-string)
                    (lambda (text &optional _paste-p)
@@ -392,7 +249,8 @@
                   ((symbol-function 'run-with-timer)
                    (lambda (_seconds _repeat function &rest arguments)
                      (setq timers
-                           (append timers (list (cons function arguments)))))))
+                           (append timers (list (cons function arguments))))
+                     'test-timer)))
           (magnus-codex-send instance "first")
           (magnus-codex-send instance "second")
           (should (equal events '("first" return)))
@@ -400,213 +258,48 @@
             (let ((timer (pop timers)))
               (apply (car timer) (cdr timer))))
           (should (equal events '("first" return "second" return))))
-      (delete-process (cdr terminal))
-      (kill-buffer (car terminal)))))
+      (magnus-test--delete-terminal terminal))))
 
-(ert-deftest magnus-codex-remote-endpoint-is-unix-only ()
-  (let ((magnus-codex-remote "ws://127.0.0.1:9000"))
-    (should-error (magnus-codex--remote-socket) :type 'user-error))
-  (let ((magnus-codex-remote "unix:///tmp/custom-codex.sock"))
-    (should (equal (magnus-codex--remote-socket)
-                   "/tmp/custom-codex.sock"))))
-
-(ert-deftest magnus-codex-stop-interrupts-active-daemon-turn ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (magnus-codex--active-turns (make-hash-table :test #'equal))
-         (instance (magnus-instances-create "/tmp" "interruptible" 'codex))
-         (observer (magnus-test--codex-process instance))
+(ert-deftest magnus-codex-stop-interrupts-and-closes-native-tui ()
+  (let* ((instance (magnus-instances-create "/tmp" "stoppable" 'codex))
          (terminal (magnus-test--codex-tui instance))
-         requested)
-    (magnus-instances-update instance :session-id "thread-stop")
-    (puthash (magnus-instance-id instance) "turn-stop"
-             magnus-codex--active-turns)
-    (unwind-protect
-        (cl-letf (((symbol-function 'magnus-codex--request)
-                   (lambda (_process method params callback)
-                     (setq requested (cons method params))
-                     (funcall callback '() nil)))
-                  ((symbol-function 'run-with-timer)
-                   (lambda (&rest _arguments) nil)))
-          (magnus-codex-stop instance)
-          (should (equal (car requested) "turn/interrupt"))
-          (should (equal (alist-get 'threadId (cdr requested)) "thread-stop"))
-          (should (equal (alist-get 'turnId (cdr requested)) "turn-stop"))
-          (should (eq (magnus-instance-status instance) 'stopped)))
-      (when (process-live-p observer) (delete-process observer))
-      (when (process-live-p (cdr terminal)) (delete-process (cdr terminal)))
-      (when (buffer-live-p (car terminal)) (kill-buffer (car terminal))))))
-
-(ert-deftest magnus-codex-stop-falls-back-to-tui-after-observer-loss ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (instance (magnus-instances-create "/tmp" "fallback-stop" 'codex))
-         (terminal (magnus-test--codex-tui instance))
+         (process (cdr terminal))
          sent-key)
-    (unwind-protect
-        (cl-letf (((symbol-function 'vterm-send-key)
-                   (lambda (key &rest _arguments) (setq sent-key key)))
-                  ((symbol-function 'run-with-timer)
-                   (lambda (_seconds _repeat function &rest arguments)
-                     (apply function arguments))))
-          (magnus-codex-stop instance)
-          (should (equal sent-key "C-c"))
-          (should (eq (magnus-instance-status instance) 'stopped))
-          (should-not (magnus-instance-buffer instance)))
-      (when (process-live-p (cdr terminal)) (delete-process (cdr terminal)))
-      (when (buffer-live-p (car terminal)) (kill-buffer (car terminal))))))
-
-(ert-deftest magnus-codex-stop-falls-back-before-turn-id-arrives ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (magnus-codex--active-turns (make-hash-table :test #'equal))
-         (instance (magnus-instances-create "/tmp" "early-stop" 'codex))
-         (observer (magnus-test--codex-process instance))
-         (terminal (magnus-test--codex-tui instance))
-         sent-key)
-    (magnus-instances-update instance :session-id "thread-early")
-    (unwind-protect
-        (cl-letf (((symbol-function 'vterm-send-key)
-                   (lambda (key &rest _arguments) (setq sent-key key)))
-                  ((symbol-function 'run-with-timer)
-                   (lambda (_seconds _repeat function &rest arguments)
-                     (apply function arguments))))
-          (magnus-codex-stop instance)
-          (should (equal sent-key "C-c"))
-          (should (eq (magnus-instance-status instance) 'stopped)))
-      (when (process-live-p observer) (delete-process observer))
-      (when (process-live-p (cdr terminal)) (delete-process (cdr terminal)))
-      (when (buffer-live-p (car terminal)) (kill-buffer (car terminal))))))
-
-(ert-deftest magnus-codex-running-state-follows-tui-not-observer ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (instance (magnus-instances-create "/tmp" "tui-codex" 'codex))
-         (observer (magnus-test--codex-process instance))
-         terminal)
-    (unwind-protect
-        (progn
-          (should-not (magnus-codex-running-p instance))
-          (setq terminal (magnus-test--codex-tui instance))
-          (should (magnus-codex-running-p instance))
-          (delete-process observer)
-          (magnus-codex--sentinel observer "exited")
-          (should (magnus-codex-running-p instance))
-          (should (eq (magnus-instance-status instance) 'running)))
-      (when terminal
-        (delete-process (cdr terminal))
-        (kill-buffer (car terminal)))
-      (when (process-live-p observer)
-        (delete-process observer)))))
+    (process-put process 'magnus-codex-capture-prompt "short-lived")
+    (process-put process 'magnus-codex-files-before nil)
+    (process-put process 'magnus-codex-capture-deadline (+ (float-time) 30))
+    (cl-letf (((symbol-function 'vterm-send-key)
+               (lambda (key &rest _arguments) (setq sent-key key)))
+              ((symbol-function 'magnus-codex--find-session-id)
+               (lambda (&rest _arguments) "session-at-stop"))
+              ((symbol-function 'run-with-timer)
+               (lambda (_seconds _repeat function &rest arguments)
+                 (apply function arguments))))
+      (magnus-codex-stop instance)
+      (should (equal sent-key "C-c"))
+      (should (equal (magnus-instance-session-id instance) "session-at-stop"))
+      (should (eq (magnus-instance-status instance) 'stopped))
+      (should-not (magnus-instance-buffer instance)))
+    (magnus-test--delete-terminal terminal)))
 
 (ert-deftest magnus-codex-stale-tui-exit-preserves-replacement ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (instance (magnus-instances-create "/tmp" "replacement" 'codex))
-         (old-observer (magnus-test--codex-process instance))
+  (let* ((instance (magnus-instances-create "/tmp" "replacement" 'codex))
          (old-terminal (magnus-test--codex-tui instance))
-         new-observer new-terminal sentinel)
+         (old-process (cdr old-terminal))
+         (new-terminal nil)
+         sentinel)
     (unwind-protect
         (progn
           (magnus-codex--setup-tui-sentinel instance (car old-terminal))
-          (setq sentinel (process-sentinel (cdr old-terminal)))
-          (setq new-observer (magnus-test--codex-process instance))
+          (setq sentinel (process-sentinel old-process))
           (setq new-terminal (magnus-test--codex-tui instance))
-          (set-process-sentinel (cdr old-terminal) nil)
-          (delete-process (cdr old-terminal))
-          (funcall sentinel (cdr old-terminal) "exited")
-          (should (process-live-p new-observer))
+          (set-process-sentinel old-process nil)
+          (delete-process old-process)
+          (funcall sentinel old-process "exited")
           (should (magnus-codex-running-p instance))
           (should (eq (magnus-instance-status instance) 'running)))
-      (dolist (process (delq nil
-                             (list old-observer new-observer
-                                   (cdr old-terminal)
-                                   (and new-terminal (cdr new-terminal)))))
-        (when (process-live-p process) (delete-process process)))
-      (dolist (buffer (delq nil
-                            (list (car old-terminal)
-                                  (and new-terminal (car new-terminal)))))
-        (when (buffer-live-p buffer) (kill-buffer buffer))))))
-
-(ert-deftest magnus-codex-stale-observer-exit-preserves-replacement-turn ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (magnus-codex--active-turns (make-hash-table :test #'equal))
-         (instance (magnus-instances-create "/tmp" "observer-race" 'codex))
-         (old-observer (magnus-test--codex-process instance))
-         new-observer)
-    (unwind-protect
-        (progn
-          (delete-process old-observer)
-          (setq new-observer (magnus-test--codex-process instance))
-          (puthash (magnus-instance-id instance) "replacement-turn"
-                   magnus-codex--active-turns)
-          (magnus-codex--sentinel old-observer "exited")
-          (should (eq (magnus-codex--connection instance) new-observer))
-          (should (equal
-                   (gethash (magnus-instance-id instance)
-                            magnus-codex--active-turns)
-                   "replacement-turn")))
-      (when (process-live-p old-observer) (delete-process old-observer))
-      (when (and new-observer (process-live-p new-observer))
-        (delete-process new-observer)))))
-
-(ert-deftest magnus-codex-existing-thread-goes-straight-to-tui ()
-  (let* ((instance (magnus-instances-create "/tmp" "handoff-codex" 'codex))
-         (process (magnus-test--codex-process instance))
-         spawned notified methods)
-    (magnus-instances-update instance :session-id "thread-existing")
-    (unwind-protect
-        (cl-letf (((symbol-function 'magnus-codex--request)
-                  (lambda (_process method params callback)
-                     (push method methods)
-                     (should params)
-                     (funcall callback
-                              (if (equal method "initialize")
-                                  '((userAgent . "test"))
-                                '((thread . ((id . "thread-existing")))))
-                              nil)))
-                  ((symbol-function 'magnus-codex--notify)
-                   (lambda (_process method &optional _params)
-                     (setq notified method)))
-                  ((symbol-function 'magnus-codex--spawn-tui)
-                   (lambda (candidate message)
-                     (setq spawned (list candidate message)))))
-          (magnus-codex--initialize process instance "first task")
-          (should (equal (magnus-instance-session-id instance)
-                         "thread-existing"))
-          (should (equal notified "initialized"))
-          (should (equal (nreverse methods)
-                         '("initialize" "thread/resume")))
-          (should (eq (car spawned) instance))
-          (should (equal (cadr spawned) "first task")))
-      (delete-process process))))
-
-(ert-deftest magnus-codex-new-threads-are-owned-by-their-observers ()
-  (let* ((first (magnus-instances-create "/tmp" "first-tui" 'codex))
-         (second (magnus-instances-create "/tmp" "second-tui" 'codex))
-         (first-process (magnus-test--codex-process first))
-         (second-process (magnus-test--codex-process second))
-         requests spawned)
-    (unwind-protect
-        (cl-letf (((symbol-function 'magnus-codex--request)
-                   (lambda (process method params callback)
-                     (push (list process method params callback) requests)))
-                  ((symbol-function 'magnus-codex--spawn-tui)
-                   (lambda (instance message)
-                     (setq spawned
-                           (append spawned
-                                   (list (list instance message)))))))
-          (magnus-codex--create-observer-thread first-process first "first")
-          (magnus-codex--create-observer-thread second-process second "second")
-          (should (= (length requests) 2))
-          (let* ((second-request (car requests))
-                 (first-request (cadr requests)))
-            (should (eq (car second-request) second-process))
-            (should (equal (cadr second-request) "thread/start"))
-            (funcall (nth 3 second-request)
-                     '((thread . ((id . "thread-second")))) nil)
-            (funcall (nth 3 first-request)
-                     '((thread . ((id . "thread-first")))) nil))
-          (should (equal (magnus-instance-session-id first) "thread-first"))
-          (should (equal (magnus-instance-session-id second) "thread-second"))
-          (should (equal (mapcar #'car spawned) (list second first))))
-      (delete-process first-process)
-      (delete-process second-process))))
+      (magnus-test--delete-terminal old-terminal)
+      (magnus-test--delete-terminal new-terminal))))
 
 (ert-deftest magnus-coord-stopped-agent-nudge-is-logged-not-signaled ()
   (let* ((directory (make-temp-file "magnus-stopped-nudge-" t))
@@ -637,9 +330,8 @@
       (delete-process process)
       (kill-buffer buffer))))
 
-(ert-deftest magnus-health-check-supports-codex-output-buffers ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (magnus-health--state (make-hash-table :test #'equal))
+(ert-deftest magnus-health-check-supports-codex-tui-buffers ()
+  (let* ((magnus-health--state (make-hash-table :test #'equal))
          (instance (magnus-instances-create "/tmp" "healthy-codex" 'codex))
          (terminal (magnus-test--codex-tui instance))
          (buffer (car terminal)))
@@ -651,8 +343,7 @@
                      (magnus-provider-call candidate 'running-p))))
           (magnus-health--check-instance instance)
           (should (eq (magnus-health-get instance) 'ok)))
-      (delete-process (cdr terminal))
-      (kill-buffer buffer))))
+      (magnus-test--delete-terminal terminal))))
 
 (provide 'magnus-provider-tests)
 ;;; magnus-provider-tests.el ends here

--- a/test/magnus-provider-tests.el
+++ b/test/magnus-provider-tests.el
@@ -7,6 +7,7 @@
 (require 'magnus-instances)
 (require 'magnus-provider)
 (require 'magnus-provider-codex)
+(require 'magnus-trace)
 (require 'magnus-coord)
 (require 'magnus-health)
 
@@ -61,6 +62,13 @@ PADDING adds an unrelated record before the first user message."
           (payload . ((type . "user_message") (message . ,prompt)))))
        "\n"))
     file))
+
+(defun magnus-test--codex-event-line (event-type message)
+  "Encode one Codex EVENT-TYPE carrying MESSAGE as JSONL."
+  (json-encode
+   `((timestamp . "2026-07-11T08:00:00.000Z")
+     (type . "event_msg")
+     (payload . ((type . ,event-type) (message . ,message))))))
 
 (ert-deftest magnus-provider-legacy-state-defaults-to-claude ()
   (let ((instance (magnus-instances-deserialize
@@ -192,6 +200,234 @@ PADDING adds an unrelated record before the first user message."
                        "session-large"))
       (delete-directory root t)
       (delete-directory directory t))))
+
+(ert-deftest magnus-codex-trace-finds-rollouts-from-old-dates ()
+  (let* ((home (make-temp-file "magnus-codex-home-" t))
+         (other-home (make-temp-file "magnus-codex-other-home-" t))
+         (process-environment (copy-sequence process-environment))
+         (magnus-codex--session-file-cache (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "old-codex" 'codex))
+         (session-id "019f-old-session")
+         (directory (expand-file-name "sessions/2024/01/02" home))
+         (file (expand-file-name
+                (format "rollout-2024-01-02T00-00-00-%s.jsonl" session-id)
+                directory))
+         (other-directory (expand-file-name "sessions/2023/12/31" other-home))
+         (other-file (expand-file-name
+                      (format "rollout-other-%s.jsonl" session-id)
+                      other-directory)))
+    (unwind-protect
+        (progn
+          (setenv "CODEX_HOME" home)
+          (make-directory directory t)
+          (with-temp-file file (insert "{}\n"))
+          (magnus-instances-update instance :session-id session-id)
+          (should (equal (magnus-codex-trace-file instance) file))
+          ;; An identical session ID under another CODEX_HOME must not reuse
+          ;; the first root's still-live cached path.
+          (setenv "CODEX_HOME" other-home)
+          (make-directory other-directory t)
+          (with-temp-file other-file (insert "{}\n"))
+          (should (equal (magnus-codex-trace-file instance) other-file)))
+      (delete-directory home t)
+      (delete-directory other-home t))))
+
+(ert-deftest magnus-codex-trace-normalizes-only-visible-events ()
+  (let* ((instance (magnus-instances-create "/tmp" "trace-codex" 'codex))
+         (user
+          (json-parse-string
+           (magnus-test--codex-event-line "user_message" "Question")
+           :object-type 'alist))
+         (agent
+          (json-parse-string
+           (magnus-test--codex-event-line "agent_message" "Answer")
+           :object-type 'alist))
+         (duplicate
+          '((type . "response_item")
+            (payload . ((type . "message") (role . "assistant")))))
+         (reasoning
+          '((type . "response_item")
+            (payload . ((type . "reasoning")
+                        (encrypted_content . "private-ciphertext"))))))
+    (should (equal
+             (alist-get 'content
+                        (alist-get 'message
+                                   (magnus-codex-trace-entry instance user)))
+             "Question"))
+    (should (equal
+             (alist-get 'text
+                        (aref (alist-get
+                               'content
+                               (alist-get 'message
+                                          (magnus-codex-trace-entry
+                                           instance agent)))
+                              0))
+             "Answer"))
+    (should-not (magnus-codex-trace-entry instance duplicate))
+    (should-not (magnus-codex-trace-entry instance reasoning))))
+
+(ert-deftest magnus-codex-trace-renders-visible-thinking-markers ()
+  (let ((instance (magnus-instances-create "/tmp" "journal-codex" 'codex)))
+    (with-temp-buffer
+      (magnus-trace-mode)
+      (setq magnus-trace--instance instance)
+      (let ((inhibit-read-only t))
+        (should
+         (magnus-trace--render-json-line
+          (magnus-test--codex-event-line
+           "agent_message"
+           (concat "[thinking]\nWorking hypothesis\n[end-thinking]\n"
+                   "[response]\nFinal answer\n[end-response]"))))
+        (should
+         (magnus-trace--render-json-line
+          (json-encode
+           '((type . "response_item")
+             (payload . ((type . "reasoning")
+                         (encrypted_content . "private-ciphertext"))))))))
+      (should (string-match-p "Working hypothesis" (buffer-string)))
+      (should (string-match-p "Final answer" (buffer-string)))
+      (should-not (string-match-p "private-ciphertext" (buffer-string)))
+      (should (cl-find-if (lambda (overlay)
+                            (overlay-get overlay 'magnus-thinking))
+                          (overlays-in (point-min) (point-max)))))))
+
+(ert-deftest magnus-codex-trace-never-runs-claude-session-inference ()
+  (let ((instance (magnus-instances-create "/tmp" "waiting-codex" 'codex)))
+    (with-temp-buffer
+      (magnus-trace-mode)
+      (setq magnus-trace--instance instance)
+      (cl-letf (((symbol-function 'magnus-process--list-sessions)
+                 (lambda (&rest _arguments)
+                   (ert-fail "Codex trace attempted Claude session discovery"))))
+        (magnus-trace-refresh))
+      (should (string-match-p "Waiting for session" (buffer-string)))
+      (should-not (magnus-instance-session-id instance)))))
+
+(ert-deftest magnus-trace-retains-partial-jsonl-records ()
+  (let* ((file (make-temp-file "magnus-trace-partial-"))
+         (instance (magnus-instances-create "/tmp" "partial-claude" 'claude))
+         (line (json-encode
+                '((type . "user")
+                  (timestamp . "2026-07-11T08:00:00.000Z")
+                  (message . ((content . "split-once"))))))
+         (split (/ (length line) 2)))
+    (unwind-protect
+        (with-temp-buffer
+          (magnus-trace-mode)
+          (setq magnus-trace--instance instance)
+          (with-temp-file file
+            (insert (substring line 0 split)))
+          (magnus-trace--append-new-entries file)
+          (should (string-empty-p (buffer-string)))
+          (should-not (string-empty-p magnus-trace--pending-text))
+          (write-region (concat (substring line split) "\n") nil file t 'silent)
+          (magnus-trace--append-new-entries file)
+          (should (= 1 (how-many "split-once" (point-min) (point-max))))
+          (should (string-empty-p magnus-trace--pending-text)))
+      (delete-file file))))
+
+(ert-deftest magnus-trace-renders-valid-final-record-without-newline ()
+  (let* ((file (make-temp-file "magnus-trace-no-newline-"))
+         (instance (magnus-instances-create "/tmp" "no-newline" 'claude)))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert
+             (json-encode
+              '((type . "user")
+                (message . ((content . "complete-without-newline")))))))
+          (with-temp-buffer
+            (magnus-trace-mode)
+            (setq magnus-trace--instance instance)
+            (magnus-trace--append-new-entries file)
+            (should (= 1 (how-many "complete-without-newline"
+                                   (point-min) (point-max))))
+            (should (string-empty-p magnus-trace--pending-text))))
+      (delete-file file))))
+
+(ert-deftest magnus-trace-malformed-line-does-not-hide-later-records ()
+  (let* ((file (make-temp-file "magnus-trace-malformed-"))
+         (instance (magnus-instances-create "/tmp" "malformed" 'claude)))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "{not-json}\n"
+                    (json-encode
+                     '((type . "user")
+                       (message . ((content . "survived-malformed")))))
+                    "\n"))
+          (with-temp-buffer
+            (magnus-trace-mode)
+            (setq magnus-trace--instance instance)
+            (magnus-trace--append-new-entries file)
+            (should (string-match-p "survived-malformed" (buffer-string)))))
+      (delete-file file))))
+
+(ert-deftest magnus-trace-switching-files-resets-rendered-state ()
+  (let* ((first (make-temp-file "magnus-trace-first-"))
+         (second (make-temp-file "magnus-trace-second-"))
+         (instance (magnus-instances-create "/tmp" "switch-claude" 'claude)))
+    (unwind-protect
+        (progn
+          (with-temp-file first
+            (insert
+             (json-encode
+              '((type . "user") (message . ((content . "first-file")))))
+             "\n"))
+          (with-temp-file second
+            (insert
+             (json-encode
+              '((type . "user") (message . ((content . "second-file")))))
+             "\n"))
+          (with-temp-buffer
+            (magnus-trace-mode)
+            (setq magnus-trace--instance instance)
+            (magnus-trace--append-new-entries first)
+            (magnus-trace--append-new-entries second)
+            (should-not (string-match-p "first-file" (buffer-string)))
+            (should (string-match-p "second-file" (buffer-string)))))
+      (delete-file first)
+      (delete-file second))))
+
+(ert-deftest magnus-trace-trim-adopts-one-atomic-snapshot ()
+  (let* ((instance (magnus-instances-create "/tmp" "trim-claude" 'claude))
+         (line (json-encode
+                '((type . "user")
+                  (message . ((content . "snapshot-message"))))))
+         (magnus-trace-max-initial-entries 1))
+    (with-temp-buffer
+      (magnus-trace-mode)
+      (setq magnus-trace--instance instance
+            magnus-trace--pending-text "stale-fragment"
+            magnus-trace--file-offset 999)
+      (cl-letf (((symbol-function 'magnus-trace--read-snapshot)
+                 (lambda (_file)
+                   (list (list line) "current-fragment" 42))))
+        (magnus-trace--trim "snapshot.jsonl"))
+      (should (= magnus-trace--file-offset 42))
+      (should (equal magnus-trace--pending-text "current-fragment"))
+      (should (string-match-p "snapshot-message" (buffer-string))))))
+
+(ert-deftest magnus-codex-trace-pagination-uses-provider-adapter ()
+  (let* ((file (make-temp-file "magnus-trace-codex-"))
+         (instance (magnus-instances-create "/tmp" "paged-codex" 'codex))
+         (magnus-trace-max-initial-entries 1))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert (magnus-test--codex-event-line "user_message" "old-message")
+                    "\n"
+                    (magnus-test--codex-event-line "agent_message" "latest")
+                    "\n"))
+          (with-temp-buffer
+            (magnus-trace-mode)
+            (setq magnus-trace--instance instance)
+            (magnus-trace--append-new-entries file)
+            (should-not (string-match-p "old-message" (buffer-string)))
+            (should (string-match-p "latest" (buffer-string)))
+            (magnus-trace-load-earlier)
+            (should (string-match-p "old-message" (buffer-string)))))
+      (delete-file file))))
 
 (ert-deftest magnus-codex-stale-capture-cannot-reassign-replacement ()
   (let* ((instance (magnus-instances-create "/tmp" "replacement" 'codex))

--- a/test/magnus-provider-tests.el
+++ b/test/magnus-provider-tests.el
@@ -26,6 +26,34 @@
              magnus-codex--connections)
     process))
 
+(defun magnus-test--codex-tui (instance)
+  "Create a live terminal-process stand-in for INSTANCE."
+  (let* ((buffer (generate-new-buffer
+                  (format " *magnus-test-tui:%s*"
+                          (magnus-instance-id instance))))
+         (process (make-pipe-process
+                   :name (generate-new-buffer-name "magnus-test-tui")
+                   :buffer buffer
+                   :noquery t)))
+    (magnus-instances-update instance :buffer buffer :status 'running)
+    (cons buffer process)))
+
+(defun magnus-test--server-websocket-frame (text)
+  "Encode TEXT as an unmasked, final server WebSocket text frame."
+  (let* ((payload (encode-coding-string text 'utf-8 t))
+         (length (length payload)))
+    (concat
+     (cond
+      ((< length 126)
+       (magnus-codex--byte-string 129 length))
+      ((< length 65536)
+       (concat (magnus-codex--byte-string 129 126)
+               (magnus-codex--integer-bytes length 2)))
+      (t
+       (concat (magnus-codex--byte-string 129 127)
+               (magnus-codex--integer-bytes length 8))))
+     payload)))
+
 (ert-deftest magnus-provider-legacy-state-defaults-to-claude ()
   (let ((instance (magnus-instances-deserialize
                    '(:id "legacy" :name "old-user"
@@ -64,6 +92,42 @@
     (should (string-match-p "Discoveries" instructions))
     (should (string-match-p "future-you" instructions))))
 
+(ert-deftest magnus-codex-parses-split-extended-websocket-frame ()
+  (let* ((instance (magnus-instances-create "/tmp" "framed-codex" 'codex))
+         (process (magnus-test--codex-process instance))
+         (padding (make-string 180 ?x))
+         (frame (magnus-test--server-websocket-frame
+                 (magnus-codex--json
+                  `((id . 1) (result . ((padding . ,padding)))))))
+         result)
+    (unwind-protect
+        (progn
+          (process-put process 'magnus-codex-frame-buffer
+                       (magnus-codex--byte-string))
+          (puthash 1
+                   (lambda (value error)
+                     (should-not error)
+                     (setq result value))
+                   (process-get process 'magnus-codex-pending))
+          (magnus-codex--consume-frames process (substring frame 0 11))
+          (should-not result)
+          (magnus-codex--consume-frames process (substring frame 11))
+          (should (equal (alist-get 'padding result) padding))
+          (should (string-empty-p
+                   (process-get process 'magnus-codex-frame-buffer))))
+      (delete-process process))))
+
+(ert-deftest magnus-codex-validates-websocket-upgrade-accept ()
+  (let* ((instance (magnus-instances-create "/tmp" "upgrade-codex" 'codex))
+         (process (magnus-test--codex-process instance)))
+    (unwind-protect
+        (progn
+          (process-put process 'magnus-codex-websocket-key
+                       "dGhlIHNhbXBsZSBub25jZQ==")
+          (should (equal (magnus-codex--websocket-accept process)
+                         "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=")))
+      (delete-process process))))
+
 (ert-deftest magnus-codex-onboards-returning-identity-from-memory ()
   (let* ((directory (make-temp-file "magnus-codex-memory-" t))
          (memory-directory
@@ -84,6 +148,18 @@
                       ".claude/agents/solar-fox/memory.md")
                      instructions))))
       (delete-directory directory t))))
+
+(ert-deftest magnus-codex-new-thread-onboarding-is-durable-user-input ()
+  (let* ((instance (magnus-instances-create "/tmp" "named-codex" 'codex))
+         (prompt (magnus-codex--onboarding-prompt instance "Fix the parser"))
+         (command (magnus-codex--tui-command instance prompt)))
+    (should (string-match-p "You are named-codex" prompt))
+    (should (string-match-p "Initial task from the user" prompt))
+    (should (string-match-p "Fix the parser" prompt))
+    (should (string-match-p "\\[thinking\\]" prompt))
+    (should (string-match-p "exec codex --remote" command))
+    (should-not (string-match-p "codex resume" command))
+    (should-not (string-match-p "developer_instructions=" command))))
 
 (ert-deftest magnus-codex-command-approval-keeps-v2-response-shape ()
   (let* ((magnus-codex--connections (make-hash-table :test #'equal))
@@ -181,73 +257,142 @@
      '((command . ("git" "status" "--short")) (cwd . "/tmp")))
     "git status --short\ncwd: /tmp")))
 
-(ert-deftest magnus-codex-active-turn-messages-queue-by-default ()
-  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
-         (magnus-codex--active-turns (make-hash-table :test #'equal))
-         (magnus-codex-active-turn-delivery 'queue)
-         (instance (magnus-instances-create "/tmp" "queued-codex" 'codex))
-         (process (magnus-test--codex-process instance))
-         requests)
+(ert-deftest magnus-codex-tui-command-resumes-managed-thread ()
+  (let* ((magnus-codex-remote "unix://")
+         (instance (magnus-instances-create
+                    "/tmp/project with spaces" "tui-codex" 'codex)))
     (magnus-instances-update instance :session-id "thread-1")
-    (puthash (magnus-instance-id instance) "turn-1"
-             magnus-codex--active-turns)
+    (let ((command (magnus-codex--tui-command
+                    instance "read this next")))
+      (should (string-match-p "codex resume" command))
+      (should (string-match-p
+               (regexp-quote
+                (format "--remote %s" (shell-quote-argument "unix://")))
+               command))
+      (should (string-match-p "thread-1" command))
+      (should (string-match-p
+               (regexp-quote (shell-quote-argument "read this next"))
+               command)))))
+
+(ert-deftest magnus-codex-messages-use-tui-as-sole-writer ()
+  (let* ((instance (magnus-instances-create "/tmp" "tui-codex" 'codex))
+         (terminal (magnus-test--codex-tui instance))
+         sent return-sent)
     (unwind-protect
-        (cl-letf (((symbol-function 'magnus-codex--insert)
-                   (lambda (&rest _arguments) nil))
-                  ((symbol-function 'magnus-codex--request)
-                   (lambda (_process method params _callback)
-                     (push (cons method params) requests)
-                     1)))
+        (cl-letf (((symbol-function 'magnus-codex--request)
+                   (lambda (&rest _arguments)
+                     (ert-fail "observer attempted an interactive request")))
+                  ((symbol-function 'vterm-send-string)
+                   (lambda (text) (setq sent text)))
+                  ((symbol-function 'vterm-send-return)
+                   (lambda () (setq return-sent t)))
+                  ((symbol-function 'run-with-timer)
+                   (lambda (_seconds _repeat function &rest arguments)
+                     (apply function arguments))))
           (magnus-codex-send instance "read this next")
-          (should-not requests)
-          (should (equal (process-get process 'magnus-codex-input-queue)
-                         '("read this next")))
-          (magnus-codex--handle-notification
-           process "turn/completed" '((turn . ((id . "turn-1")))))
-          (should (equal (caar requests) "turn/start"))
-          (should-not (process-get process 'magnus-codex-input-queue)))
+          (should (equal sent "read this next"))
+          (should return-sent))
+      (delete-process (cdr terminal))
+      (kill-buffer (car terminal)))))
+
+(ert-deftest magnus-codex-running-state-follows-tui-not-observer ()
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "tui-codex" 'codex))
+         (observer (magnus-test--codex-process instance))
+         terminal)
+    (unwind-protect
+        (progn
+          (should-not (magnus-codex-running-p instance))
+          (setq terminal (magnus-test--codex-tui instance))
+          (should (magnus-codex-running-p instance))
+          (delete-process observer)
+          (magnus-codex--sentinel observer "exited")
+          (should (magnus-codex-running-p instance))
+          (should (eq (magnus-instance-status instance) 'running)))
+      (when terminal
+        (delete-process (cdr terminal))
+        (kill-buffer (car terminal)))
+      (when (process-live-p observer)
+        (delete-process observer)))))
+
+(ert-deftest magnus-codex-stale-tui-exit-preserves-replacement ()
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "replacement" 'codex))
+         (old-observer (magnus-test--codex-process instance))
+         (old-terminal (magnus-test--codex-tui instance))
+         new-observer new-terminal sentinel)
+    (unwind-protect
+        (progn
+          (magnus-codex--setup-tui-sentinel instance (car old-terminal))
+          (setq sentinel (process-sentinel (cdr old-terminal)))
+          (setq new-observer (magnus-test--codex-process instance))
+          (setq new-terminal (magnus-test--codex-tui instance))
+          (set-process-sentinel (cdr old-terminal) nil)
+          (delete-process (cdr old-terminal))
+          (funcall sentinel (cdr old-terminal) "exited")
+          (should (process-live-p new-observer))
+          (should (magnus-codex-running-p instance))
+          (should (eq (magnus-instance-status instance) 'running)))
+      (dolist (process (delq nil
+                             (list old-observer new-observer
+                                   (cdr old-terminal)
+                                   (and new-terminal (cdr new-terminal)))))
+        (when (process-live-p process) (delete-process process)))
+      (dolist (buffer (delq nil
+                            (list (car old-terminal)
+                                  (and new-terminal (car new-terminal)))))
+        (when (buffer-live-p buffer) (kill-buffer buffer))))))
+
+(ert-deftest magnus-codex-open-thread-hands-session-to-tui ()
+  (let* ((instance (magnus-instances-create "/tmp" "handoff-codex" 'codex))
+         (process (magnus-test--codex-process instance))
+         spawned)
+    (magnus-instances-update instance :session-id "thread-existing")
+    (unwind-protect
+        (cl-letf (((symbol-function 'magnus-codex--request)
+                   (lambda (_process method params callback)
+                     (should (equal method "thread/resume"))
+                     (should (equal (alist-get 'threadId params)
+                                    "thread-existing"))
+                     (funcall callback
+                              '((thread . ((id . "thread-existing")))) nil)))
+                  ((symbol-function 'magnus-codex--spawn-tui)
+                   (lambda (candidate message)
+                     (setq spawned (list candidate message)))))
+          (magnus-codex--open-thread process instance "first task")
+          (should (equal (magnus-instance-session-id instance)
+                         "thread-existing"))
+          (should (eq (car spawned) instance))
+          (should (equal (cadr spawned) "first task")))
       (delete-process process))))
 
-(ert-deftest magnus-codex-inline-input-preserves-draft-during-output ()
-  (let* ((instance (magnus-instances-create "/tmp" "inline-codex" 'codex))
-         (buffer (magnus-codex--buffer instance)))
+(ert-deftest magnus-codex-new-tui-handoffs-are-serialized ()
+  (let* ((magnus-codex--new-thread-owner nil)
+         (magnus-codex--new-thread-queue nil)
+         (first (magnus-instances-create "/tmp" "first-tui" 'codex))
+         (second (magnus-instances-create "/tmp" "second-tui" 'codex))
+         (first-process (magnus-test--codex-process first))
+         (second-process (magnus-test--codex-process second))
+         spawned)
     (unwind-protect
-        (with-current-buffer buffer
-          (goto-char (point-max))
-          (insert "unfinished draft")
-          (magnus-codex--insert instance "streamed output\n")
-          (should
-           (equal (buffer-substring-no-properties
-                   magnus-codex--input-marker (point-max))
-                  "unfinished draft"))
-          (should
-           (string-match-p
-            "streamed output"
-            (buffer-substring-no-properties
-             (point-min) magnus-codex--prompt-marker))))
-      (kill-buffer buffer))))
-
-(ert-deftest magnus-codex-inline-input-submits-with-return-command ()
-  (let* ((instance (magnus-instances-create "/tmp" "submit-codex" 'codex))
-         (buffer (magnus-codex--buffer instance))
-         sent)
-    (unwind-protect
-        (with-current-buffer buffer
-          (should (eq (key-binding (kbd "x"))
-                      'magnus-codex-self-insert))
-          (should (eq (key-binding (kbd "RET"))
-                      'magnus-codex-submit-input))
-          (goto-char (point-max))
-          (insert "hello wise-deer")
-          (cl-letf (((symbol-function 'magnus-codex-send)
-                     (lambda (_instance text) (setq sent text))))
-            (magnus-codex-submit-input))
-          (should (equal sent "hello wise-deer"))
-          (should
-           (string-empty-p
-            (buffer-substring-no-properties
-             magnus-codex--input-marker (point-max)))))
-      (kill-buffer buffer))))
+        (cl-letf (((symbol-function 'magnus-codex--spawn-tui)
+                   (lambda (instance message)
+                     (setq spawned
+                           (append spawned
+                                   (list (list instance message)))))))
+          (magnus-codex--start-new-thread first-process first "first")
+          (magnus-codex--start-new-thread second-process second "second")
+          (should (equal (mapcar #'car spawned) (list first)))
+          (should (= (length magnus-codex--new-thread-queue) 1))
+          (magnus-codex--handle-notification
+           first-process "thread/started"
+           '((thread . ((id . "thread-first") (cwd . "/tmp")))))
+          (should (equal (magnus-instance-session-id first) "thread-first"))
+          (should (equal (mapcar #'car spawned) (list first second)))
+          (should (equal magnus-codex--new-thread-owner
+                         (magnus-instance-id second))))
+      (delete-process first-process)
+      (delete-process second-process))))
 
 (ert-deftest magnus-coord-stopped-agent-nudge-is-logged-not-signaled ()
   (let* ((directory (make-temp-file "magnus-stopped-nudge-" t))
@@ -271,9 +416,8 @@
   (let* ((magnus-codex--connections (make-hash-table :test #'equal))
          (magnus-health--state (make-hash-table :test #'equal))
          (instance (magnus-instances-create "/tmp" "healthy-codex" 'codex))
-         (process (magnus-test--codex-process instance))
-         (buffer (generate-new-buffer " *healthy-codex*")))
-    (magnus-instances-update instance :status 'running :buffer buffer)
+         (terminal (magnus-test--codex-tui instance))
+         (buffer (car terminal)))
     (with-current-buffer buffer
       (insert "streamed Codex output"))
     (unwind-protect
@@ -282,8 +426,8 @@
                      (magnus-provider-call candidate 'running-p))))
           (magnus-health--check-instance instance)
           (should (eq (magnus-health-get instance) 'ok)))
-      (kill-buffer buffer)
-      (delete-process process))))
+      (delete-process (cdr terminal))
+      (kill-buffer buffer))))
 
 (provide 'magnus-provider-tests)
 ;;; magnus-provider-tests.el ends here

--- a/test/magnus-provider-tests.el
+++ b/test/magnus-provider-tests.el
@@ -1,0 +1,107 @@
+;;; magnus-provider-tests.el --- Provider compatibility tests -*- lexical-binding: t -*-
+
+(require 'ert)
+(require 'cl-lib)
+(require 'magnus-instances)
+(require 'magnus-provider)
+(require 'magnus-provider-codex)
+
+(ert-deftest magnus-provider-legacy-state-defaults-to-claude ()
+  (let ((instance (magnus-instances-deserialize
+                   '(:id "legacy" :name "old-user"
+                     :directory "/tmp" :status stopped))))
+    (should (eq (magnus-instance-provider instance) 'claude))
+    (should-not (magnus-provider-external-p instance))))
+
+(ert-deftest magnus-provider-round-trips-codex-state ()
+  (let* ((instance (magnus-instances-create "/tmp" "codex-user" 'codex))
+         (restored (magnus-instances-deserialize
+                    (magnus-instances-serialize instance))))
+    (should (eq (magnus-instance-provider restored) 'codex))
+    (should (magnus-provider-external-p restored))))
+
+(ert-deftest magnus-provider-unknown-never-falls-back-to-claude ()
+  (let ((instance (magnus-instances-create "/tmp" "unknown" 'not-a-provider)))
+    (should (magnus-provider-external-p instance))
+    (should-error (magnus-provider-call instance 'start) :type 'user-error)))
+
+(ert-deftest magnus-codex-parses-current-app-server-events ()
+  (let ((message
+         (magnus-codex--parse-line
+          "{\"jsonrpc\":\"2.0\",\"method\":\"item/agentMessage/delta\",\"params\":{\"delta\":\"hi\"}}")))
+    (should (equal (alist-get 'method message) "item/agentMessage/delta"))
+    (should (equal (alist-get 'delta (alist-get 'params message)) "hi")))
+  (should (equal (magnus-codex--input "hello")
+                 '[((type . "text") (text . "hello"))]))
+  (should (equal (magnus-codex--thread-status-name
+                  '((type . "active") (activeFlags . [])))
+                 "active"))
+  (let* ((instance (magnus-instances-create "/tmp" "solar-fox" 'codex))
+         (instructions (magnus-codex--instructions instance)))
+    (should (string-match-p "solar-fox" instructions))
+    (should (string-match-p "\\[thinking\\]" instructions))
+    (should (string-match-p "visible working notebook" instructions))
+    (should (string-match-p "Discoveries" instructions))
+    (should (string-match-p "future-you" instructions))))
+
+(ert-deftest magnus-codex-onboards-returning-identity-from-memory ()
+  (let* ((directory (make-temp-file "magnus-codex-memory-" t))
+         (memory-directory
+          (expand-file-name ".claude/agents/solar-fox" directory))
+         (memory-file (expand-file-name "memory.md" memory-directory)))
+    (unwind-protect
+        (progn
+          (make-directory memory-directory t)
+          (with-temp-file memory-file
+            (insert "# Solar Fox\n\nI remember this project.\n"))
+          (let* ((instance (magnus-instances-create
+                            directory "solar-fox" 'codex))
+                 (instructions (magnus-codex--instructions instance)))
+            (should (string-match-p "been here before" instructions))
+            (should (string-match-p "own prior voice" instructions))
+            (should (string-match-p
+                     (regexp-quote
+                      ".claude/agents/solar-fox/memory.md")
+                     instructions))))
+      (delete-directory directory t))))
+
+(ert-deftest magnus-codex-command-approval-keeps-v2-response-shape ()
+  (let* ((instance (magnus-instances-create "/tmp" "codex-user" 'codex))
+         (request-id 7)
+         sent)
+    (puthash request-id
+             (list :instance instance :process 'fake-process
+                   :method "item/commandExecution/requestApproval")
+             magnus-codex--approvals)
+    (cl-letf (((symbol-function 'magnus-codex--send-object)
+               (lambda (_process object) (setq sent object)))
+              ((symbol-function 'magnus-codex--insert)
+               (lambda (&rest _arguments) nil)))
+      (magnus-codex-respond-approval instance request-id "accept"))
+    (should (equal (alist-get 'result sent)
+                   '((decision . "accept"))))))
+
+(ert-deftest magnus-codex-permission-approval-requires-profile ()
+  (let* ((instance (magnus-instances-create "/tmp" "codex-user" 'codex))
+         (request-id 8))
+    (puthash request-id
+             (list :instance instance :process 'fake-process
+                   :method "item/permissions/requestApproval")
+             magnus-codex--approvals)
+    (should-error
+     (magnus-codex-respond-approval instance request-id "accept")
+     :type 'user-error)))
+
+(ert-deftest magnus-codex-rejects-unknown-command-approval-decision ()
+  (let* ((instance (magnus-instances-create "/tmp" "codex-user" 'codex))
+         (request-id 9))
+    (puthash request-id
+             (list :instance instance :process 'fake-process
+                   :method "item/fileChange/requestApproval")
+             magnus-codex--approvals)
+    (should-error
+     (magnus-codex-respond-approval instance request-id "approve-everything")
+     :type 'user-error)))
+
+(provide 'magnus-provider-tests)
+;;; magnus-provider-tests.el ends here

--- a/test/magnus-provider-tests.el
+++ b/test/magnus-provider-tests.el
@@ -208,6 +208,47 @@
           (should-not (process-get process 'magnus-codex-input-queue)))
       (delete-process process))))
 
+(ert-deftest magnus-codex-inline-input-preserves-draft-during-output ()
+  (let* ((instance (magnus-instances-create "/tmp" "inline-codex" 'codex))
+         (buffer (magnus-codex--buffer instance)))
+    (unwind-protect
+        (with-current-buffer buffer
+          (goto-char (point-max))
+          (insert "unfinished draft")
+          (magnus-codex--insert instance "streamed output\n")
+          (should
+           (equal (buffer-substring-no-properties
+                   magnus-codex--input-marker (point-max))
+                  "unfinished draft"))
+          (should
+           (string-match-p
+            "streamed output"
+            (buffer-substring-no-properties
+             (point-min) magnus-codex--prompt-marker))))
+      (kill-buffer buffer))))
+
+(ert-deftest magnus-codex-inline-input-submits-with-return-command ()
+  (let* ((instance (magnus-instances-create "/tmp" "submit-codex" 'codex))
+         (buffer (magnus-codex--buffer instance))
+         sent)
+    (unwind-protect
+        (with-current-buffer buffer
+          (should (eq (key-binding (kbd "x"))
+                      'magnus-codex-self-insert))
+          (should (eq (key-binding (kbd "RET"))
+                      'magnus-codex-submit-input))
+          (goto-char (point-max))
+          (insert "hello wise-deer")
+          (cl-letf (((symbol-function 'magnus-codex-send)
+                     (lambda (_instance text) (setq sent text))))
+            (magnus-codex-submit-input))
+          (should (equal sent "hello wise-deer"))
+          (should
+           (string-empty-p
+            (buffer-substring-no-properties
+             magnus-codex--input-marker (point-max)))))
+      (kill-buffer buffer))))
+
 (ert-deftest magnus-coord-stopped-agent-nudge-is-logged-not-signaled ()
   (let* ((directory (make-temp-file "magnus-stopped-nudge-" t))
          (instance (magnus-instances-create directory "stopped-codex" 'codex))

--- a/test/magnus-provider-tests.el
+++ b/test/magnus-provider-tests.el
@@ -2,6 +2,7 @@
 
 (require 'ert)
 (require 'cl-lib)
+(require 'magnus)
 (require 'magnus-instances)
 (require 'magnus-provider)
 (require 'magnus-provider-codex)
@@ -20,10 +21,8 @@
                  (make-hash-table :test #'equal))
     (process-put process 'magnus-codex-approvals
                  (make-hash-table :test #'equal))
-    (process-put process 'magnus-codex-input-queue nil)
     (process-put process 'magnus-codex-turn-starting nil)
-    (puthash (magnus-instance-id instance) process
-             magnus-codex--connections)
+    (magnus-codex--register-connection instance process)
     process))
 
 (defun magnus-test--codex-tui (instance)
@@ -60,6 +59,11 @@
                      :directory "/tmp" :status stopped))))
     (should (eq (magnus-instance-provider instance) 'claude))
     (should-not (magnus-provider-external-p instance))))
+
+(ert-deftest magnus-upgrade-requires-restart-before-reinitialization ()
+  (let ((magnus--restart-required t)
+        (magnus--initialized nil))
+    (should-error (magnus--ensure-initialized) :type 'user-error)))
 
 (ert-deftest magnus-provider-round-trips-codex-state ()
   (let* ((instance (magnus-instances-create "/tmp" "codex-user" 'codex))
@@ -158,15 +162,16 @@
 
 (ert-deftest magnus-codex-new-thread-onboarding-is-durable-user-input ()
   (let* ((instance (magnus-instances-create "/tmp" "named-codex" 'codex))
-         (prompt (magnus-codex--onboarding-prompt instance "Fix the parser"))
-         (command (magnus-codex--tui-command instance prompt)))
+         (prompt (magnus-codex--onboarding-prompt instance "Fix the parser")))
     (should (string-match-p "You are named-codex" prompt))
     (should (string-match-p "Initial task from the user" prompt))
     (should (string-match-p "Fix the parser" prompt))
     (should (string-match-p "\\[thinking\\]" prompt))
-    (should (string-match-p "exec codex --remote" command))
-    (should-not (string-match-p "codex resume" command))
-    (should-not (string-match-p "developer_instructions=" command))))
+    (magnus-instances-update instance :session-id "observer-owned-thread")
+    (let ((command (magnus-codex--tui-command instance prompt)))
+      (should (string-match-p "exec codex resume" command))
+      (should (string-match-p "observer-owned-thread" command))
+      (should-not (string-match-p "developer_instructions=" command)))))
 
 (ert-deftest magnus-codex-command-approval-keeps-v2-response-shape ()
   (let* ((magnus-codex--connections (make-hash-table :test #'equal))
@@ -187,6 +192,29 @@
             (magnus-codex-respond-approval instance request-id "accept"))
           (should (equal (alist-get 'result sent)
                          '((decision . "accept")))))
+      (delete-process process))))
+
+(ert-deftest magnus-codex-command-approval-allows-policy-amendment ()
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "policy-codex" 'codex))
+         (process (magnus-test--codex-process instance))
+         (decision
+          '((acceptWithExecpolicyAmendment
+             . ((execpolicy_amendment . ("git" "status"))))))
+         sent)
+    (unwind-protect
+        (progn
+          (puthash 12
+                   (list :instance instance :process process
+                         :method "item/commandExecution/requestApproval")
+                   (magnus-codex--approval-table process))
+          (cl-letf (((symbol-function 'magnus-codex--send-object)
+                     (lambda (_process object) (setq sent object)))
+                    ((symbol-function 'magnus-codex--insert)
+                     (lambda (&rest _arguments) nil)))
+            (magnus-codex-respond-approval instance 12 decision))
+          (should (equal (alist-get 'result sent)
+                         `((decision . ,decision)))))
       (delete-process process))))
 
 (ert-deftest magnus-codex-permission-approval-requires-profile ()
@@ -229,6 +257,8 @@
          (first-process (magnus-test--codex-process first))
          (second-process (magnus-test--codex-process second))
          sent)
+    (magnus-instances-update first :session-id "thread-first")
+    (magnus-instances-update second :session-id "thread-second")
     (unwind-protect
         (cl-letf (((symbol-function 'magnus-codex--insert)
                    (lambda (&rest _arguments) nil))
@@ -237,10 +267,10 @@
                      (push (cons process object) sent))))
           (magnus-codex--handle-server-request
            first-process 3 "item/commandExecution/requestApproval"
-           '((command . "git status")))
+           '((threadId . "thread-first") (command . "git status")))
           (magnus-codex--handle-server-request
            second-process 3 "item/fileChange/requestApproval"
-           '((reason . "edit file")))
+           '((threadId . "thread-second") (reason . "edit file")))
           (should (= 1 (hash-table-count
                         (magnus-codex--approval-table first-process))))
           (should (= 1 (hash-table-count
@@ -256,6 +286,43 @@
           (should (= 2 (length sent))))
       (delete-process first-process)
       (delete-process second-process))))
+
+(ert-deftest magnus-codex-stale-approval-cannot-answer-reused-id ()
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (magnus-codex--retired-approval-ids
+          (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "reconnected" 'codex))
+         (first-process (magnus-test--codex-process instance))
+         second-process old-token current-token sent)
+    (magnus-instances-update instance :session-id "thread-reconnected")
+    (unwind-protect
+        (cl-letf (((symbol-function 'magnus-codex--insert)
+                   (lambda (&rest _arguments) nil))
+                  ((symbol-function 'magnus-codex--send-object)
+                   (lambda (_process object) (setq sent object))))
+          (magnus-codex--handle-server-request
+           first-process 3 "item/commandExecution/requestApproval"
+           '((threadId . "thread-reconnected") (command . "old")))
+          (setq old-token (magnus-codex-approval-token instance 3))
+          (delete-process first-process)
+          (setq second-process (magnus-test--codex-process instance))
+          (magnus-codex--handle-server-request
+           second-process 3 "item/commandExecution/requestApproval"
+           '((threadId . "thread-reconnected") (command . "new")))
+          (setq current-token (magnus-codex-approval-token instance 3))
+          (should-error
+           (magnus-codex-respond-approval instance 3 "accept")
+           :type 'user-error)
+          (should-error
+           (magnus-codex-respond-approval instance 3 "accept" old-token)
+           :type 'user-error)
+          (magnus-codex-respond-approval
+           instance 3 "accept" current-token)
+          (should (equal (alist-get 'result sent)
+                         '((decision . "accept")))))
+      (when (process-live-p first-process) (delete-process first-process))
+      (when (and second-process (process-live-p second-process))
+        (delete-process second-process)))))
 
 (ert-deftest magnus-codex-approval-summary-accepts-argv-arrays ()
   (should
@@ -282,15 +349,20 @@
                command)))))
 
 (ert-deftest magnus-codex-messages-use-tui-as-sole-writer ()
-  (let* ((instance (magnus-instances-create "/tmp" "tui-codex" 'codex))
+  (let* ((magnus-codex--input-queues (make-hash-table :test #'equal))
+         (magnus-codex--input-busy (make-hash-table :test #'equal))
+         (magnus-codex--input-retry (make-hash-table :test #'equal))
+         (magnus-codex--tui-ready (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "tui-codex" 'codex))
          (terminal (magnus-test--codex-tui instance))
          sent return-sent)
+    (puthash (magnus-instance-id instance) t magnus-codex--tui-ready)
     (unwind-protect
         (cl-letf (((symbol-function 'magnus-codex--request)
-                   (lambda (&rest _arguments)
+                  (lambda (&rest _arguments)
                      (ert-fail "observer attempted an interactive request")))
                   ((symbol-function 'vterm-send-string)
-                   (lambda (text) (setq sent text)))
+                   (lambda (text &optional _paste-p) (setq sent text)))
                   ((symbol-function 'vterm-send-return)
                    (lambda () (setq return-sent t)))
                   ((symbol-function 'run-with-timer)
@@ -301,6 +373,107 @@
           (should return-sent))
       (delete-process (cdr terminal))
       (kill-buffer (car terminal)))))
+
+(ert-deftest magnus-codex-concurrent-tui-messages-are-serialized ()
+  (let* ((magnus-codex--input-queues (make-hash-table :test #'equal))
+         (magnus-codex--input-busy (make-hash-table :test #'equal))
+         (magnus-codex--input-retry (make-hash-table :test #'equal))
+         (magnus-codex--tui-ready (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "queued-codex" 'codex))
+         (terminal (magnus-test--codex-tui instance))
+         timers events)
+    (puthash (magnus-instance-id instance) t magnus-codex--tui-ready)
+    (unwind-protect
+        (cl-letf (((symbol-function 'vterm-send-string)
+                   (lambda (text &optional _paste-p)
+                     (setq events (append events (list text)))))
+                  ((symbol-function 'vterm-send-return)
+                   (lambda () (setq events (append events '(return)))))
+                  ((symbol-function 'run-with-timer)
+                   (lambda (_seconds _repeat function &rest arguments)
+                     (setq timers
+                           (append timers (list (cons function arguments)))))))
+          (magnus-codex-send instance "first")
+          (magnus-codex-send instance "second")
+          (should (equal events '("first" return)))
+          (while timers
+            (let ((timer (pop timers)))
+              (apply (car timer) (cdr timer))))
+          (should (equal events '("first" return "second" return))))
+      (delete-process (cdr terminal))
+      (kill-buffer (car terminal)))))
+
+(ert-deftest magnus-codex-remote-endpoint-is-unix-only ()
+  (let ((magnus-codex-remote "ws://127.0.0.1:9000"))
+    (should-error (magnus-codex--remote-socket) :type 'user-error))
+  (let ((magnus-codex-remote "unix:///tmp/custom-codex.sock"))
+    (should (equal (magnus-codex--remote-socket)
+                   "/tmp/custom-codex.sock"))))
+
+(ert-deftest magnus-codex-stop-interrupts-active-daemon-turn ()
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (magnus-codex--active-turns (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "interruptible" 'codex))
+         (observer (magnus-test--codex-process instance))
+         (terminal (magnus-test--codex-tui instance))
+         requested)
+    (magnus-instances-update instance :session-id "thread-stop")
+    (puthash (magnus-instance-id instance) "turn-stop"
+             magnus-codex--active-turns)
+    (unwind-protect
+        (cl-letf (((symbol-function 'magnus-codex--request)
+                   (lambda (_process method params callback)
+                     (setq requested (cons method params))
+                     (funcall callback '() nil)))
+                  ((symbol-function 'run-with-timer)
+                   (lambda (&rest _arguments) nil)))
+          (magnus-codex-stop instance)
+          (should (equal (car requested) "turn/interrupt"))
+          (should (equal (alist-get 'threadId (cdr requested)) "thread-stop"))
+          (should (equal (alist-get 'turnId (cdr requested)) "turn-stop"))
+          (should (eq (magnus-instance-status instance) 'stopped)))
+      (when (process-live-p observer) (delete-process observer))
+      (when (process-live-p (cdr terminal)) (delete-process (cdr terminal)))
+      (when (buffer-live-p (car terminal)) (kill-buffer (car terminal))))))
+
+(ert-deftest magnus-codex-stop-falls-back-to-tui-after-observer-loss ()
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "fallback-stop" 'codex))
+         (terminal (magnus-test--codex-tui instance))
+         sent-key)
+    (unwind-protect
+        (cl-letf (((symbol-function 'vterm-send-key)
+                   (lambda (key &rest _arguments) (setq sent-key key)))
+                  ((symbol-function 'run-with-timer)
+                   (lambda (_seconds _repeat function &rest arguments)
+                     (apply function arguments))))
+          (magnus-codex-stop instance)
+          (should (equal sent-key "C-c"))
+          (should (eq (magnus-instance-status instance) 'stopped))
+          (should-not (magnus-instance-buffer instance)))
+      (when (process-live-p (cdr terminal)) (delete-process (cdr terminal)))
+      (when (buffer-live-p (car terminal)) (kill-buffer (car terminal))))))
+
+(ert-deftest magnus-codex-stop-falls-back-before-turn-id-arrives ()
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (magnus-codex--active-turns (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "early-stop" 'codex))
+         (observer (magnus-test--codex-process instance))
+         (terminal (magnus-test--codex-tui instance))
+         sent-key)
+    (magnus-instances-update instance :session-id "thread-early")
+    (unwind-protect
+        (cl-letf (((symbol-function 'vterm-send-key)
+                   (lambda (key &rest _arguments) (setq sent-key key)))
+                  ((symbol-function 'run-with-timer)
+                   (lambda (_seconds _repeat function &rest arguments)
+                     (apply function arguments))))
+          (magnus-codex-stop instance)
+          (should (equal sent-key "C-c"))
+          (should (eq (magnus-instance-status instance) 'stopped)))
+      (when (process-live-p observer) (delete-process observer))
+      (when (process-live-p (cdr terminal)) (delete-process (cdr terminal)))
+      (when (buffer-live-p (car terminal)) (kill-buffer (car terminal))))))
 
 (ert-deftest magnus-codex-running-state-follows-tui-not-observer ()
   (let* ((magnus-codex--connections (make-hash-table :test #'equal))
@@ -350,17 +523,43 @@
                                   (and new-terminal (car new-terminal)))))
         (when (buffer-live-p buffer) (kill-buffer buffer))))))
 
+(ert-deftest magnus-codex-stale-observer-exit-preserves-replacement-turn ()
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (magnus-codex--active-turns (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "observer-race" 'codex))
+         (old-observer (magnus-test--codex-process instance))
+         new-observer)
+    (unwind-protect
+        (progn
+          (delete-process old-observer)
+          (setq new-observer (magnus-test--codex-process instance))
+          (puthash (magnus-instance-id instance) "replacement-turn"
+                   magnus-codex--active-turns)
+          (magnus-codex--sentinel old-observer "exited")
+          (should (eq (magnus-codex--connection instance) new-observer))
+          (should (equal
+                   (gethash (magnus-instance-id instance)
+                            magnus-codex--active-turns)
+                   "replacement-turn")))
+      (when (process-live-p old-observer) (delete-process old-observer))
+      (when (and new-observer (process-live-p new-observer))
+        (delete-process new-observer)))))
+
 (ert-deftest magnus-codex-existing-thread-goes-straight-to-tui ()
   (let* ((instance (magnus-instances-create "/tmp" "handoff-codex" 'codex))
          (process (magnus-test--codex-process instance))
-         spawned notified)
+         spawned notified methods)
     (magnus-instances-update instance :session-id "thread-existing")
     (unwind-protect
         (cl-letf (((symbol-function 'magnus-codex--request)
-                   (lambda (_process method params callback)
-                     (should (equal method "initialize"))
+                  (lambda (_process method params callback)
+                     (push method methods)
                      (should params)
-                     (funcall callback '((userAgent . "test")) nil)))
+                     (funcall callback
+                              (if (equal method "initialize")
+                                  '((userAgent . "test"))
+                                '((thread . ((id . "thread-existing")))))
+                              nil)))
                   ((symbol-function 'magnus-codex--notify)
                    (lambda (_process method &optional _params)
                      (setq notified method)))
@@ -371,35 +570,41 @@
           (should (equal (magnus-instance-session-id instance)
                          "thread-existing"))
           (should (equal notified "initialized"))
+          (should (equal (nreverse methods)
+                         '("initialize" "thread/resume")))
           (should (eq (car spawned) instance))
           (should (equal (cadr spawned) "first task")))
       (delete-process process))))
 
-(ert-deftest magnus-codex-new-tui-handoffs-are-serialized ()
-  (let* ((magnus-codex--new-thread-owner nil)
-         (magnus-codex--new-thread-queue nil)
-         (first (magnus-instances-create "/tmp" "first-tui" 'codex))
+(ert-deftest magnus-codex-new-threads-are-owned-by-their-observers ()
+  (let* ((first (magnus-instances-create "/tmp" "first-tui" 'codex))
          (second (magnus-instances-create "/tmp" "second-tui" 'codex))
          (first-process (magnus-test--codex-process first))
          (second-process (magnus-test--codex-process second))
-         spawned)
+         requests spawned)
     (unwind-protect
-        (cl-letf (((symbol-function 'magnus-codex--spawn-tui)
+        (cl-letf (((symbol-function 'magnus-codex--request)
+                   (lambda (process method params callback)
+                     (push (list process method params callback) requests)))
+                  ((symbol-function 'magnus-codex--spawn-tui)
                    (lambda (instance message)
                      (setq spawned
                            (append spawned
                                    (list (list instance message)))))))
-          (magnus-codex--start-new-thread first-process first "first")
-          (magnus-codex--start-new-thread second-process second "second")
-          (should (equal (mapcar #'car spawned) (list first)))
-          (should (= (length magnus-codex--new-thread-queue) 1))
-          (magnus-codex--handle-notification
-           first-process "thread/started"
-           '((thread . ((id . "thread-first") (cwd . "/tmp")))))
+          (magnus-codex--create-observer-thread first-process first "first")
+          (magnus-codex--create-observer-thread second-process second "second")
+          (should (= (length requests) 2))
+          (let* ((second-request (car requests))
+                 (first-request (cadr requests)))
+            (should (eq (car second-request) second-process))
+            (should (equal (cadr second-request) "thread/start"))
+            (funcall (nth 3 second-request)
+                     '((thread . ((id . "thread-second")))) nil)
+            (funcall (nth 3 first-request)
+                     '((thread . ((id . "thread-first")))) nil))
           (should (equal (magnus-instance-session-id first) "thread-first"))
-          (should (equal (mapcar #'car spawned) (list first second)))
-          (should (equal magnus-codex--new-thread-owner
-                         (magnus-instance-id second))))
+          (should (equal (magnus-instance-session-id second) "thread-second"))
+          (should (equal (mapcar #'car spawned) (list second first))))
       (delete-process first-process)
       (delete-process second-process))))
 
@@ -408,8 +613,7 @@
          (instance (magnus-instances-create directory "stopped-codex" 'codex))
          (magnus-coord-nudge-debounce nil))
     (unwind-protect
-        (cl-letf (((symbol-function 'magnus-process-running-p)
-                   (lambda (_instance) nil)))
+        (progn
           (should-not
            (magnus-coord-nudge-agent
             instance "Please tell @bold-wren later" "Magnus"))
@@ -420,6 +624,18 @@
             (should (string-match-p "Undelivered nudge" log))
             (should (string-match-p "(at) bold-wren" log))))
       (delete-directory directory t))))
+
+(ert-deftest magnus-coord-legacy-running-check-needs-no-process-module-call ()
+  (let* ((instance (magnus-instances-create "/tmp" "legacy-live" 'claude))
+         (buffer (generate-new-buffer " *magnus-legacy-live*"))
+         (process (make-pipe-process
+                   :name (generate-new-buffer-name "magnus-legacy-live")
+                   :buffer buffer :noquery t)))
+    (magnus-instances-update instance :buffer buffer :status 'running)
+    (unwind-protect
+        (should (magnus-coord--instance-running-p instance))
+      (delete-process process)
+      (kill-buffer buffer))))
 
 (ert-deftest magnus-health-check-supports-codex-output-buffers ()
   (let* ((magnus-codex--connections (make-hash-table :test #'equal))

--- a/test/magnus-provider-tests.el
+++ b/test/magnus-provider-tests.el
@@ -40,7 +40,7 @@
 
 (defun magnus-test--server-websocket-frame (text)
   "Encode TEXT as an unmasked, final server WebSocket text frame."
-  (let* ((payload (encode-coding-string text 'utf-8 t))
+  (let* ((payload (encode-coding-string text 'utf-8))
          (length (length payload)))
     (concat
      (cond
@@ -127,6 +127,13 @@
           (should (equal (magnus-codex--websocket-accept process)
                          "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=")))
       (delete-process process))))
+
+(ert-deftest magnus-codex-client-websocket-frames-are-unibyte ()
+  (let ((frame (magnus-codex--websocket-frame
+                "A deliberately ASCII JSON payload long enough to mask")))
+    (should-not (multibyte-string-p frame))
+    (should (= (aref frame 0) 129))
+    (should-not (zerop (logand (aref frame 1) 128)))))
 
 (ert-deftest magnus-codex-onboards-returning-identity-from-memory ()
   (let* ((directory (make-temp-file "magnus-codex-memory-" t))
@@ -343,25 +350,27 @@
                                   (and new-terminal (car new-terminal)))))
         (when (buffer-live-p buffer) (kill-buffer buffer))))))
 
-(ert-deftest magnus-codex-open-thread-hands-session-to-tui ()
+(ert-deftest magnus-codex-existing-thread-goes-straight-to-tui ()
   (let* ((instance (magnus-instances-create "/tmp" "handoff-codex" 'codex))
          (process (magnus-test--codex-process instance))
-         spawned)
+         spawned notified)
     (magnus-instances-update instance :session-id "thread-existing")
     (unwind-protect
         (cl-letf (((symbol-function 'magnus-codex--request)
                    (lambda (_process method params callback)
-                     (should (equal method "thread/resume"))
-                     (should (equal (alist-get 'threadId params)
-                                    "thread-existing"))
-                     (funcall callback
-                              '((thread . ((id . "thread-existing")))) nil)))
+                     (should (equal method "initialize"))
+                     (should params)
+                     (funcall callback '((userAgent . "test")) nil)))
+                  ((symbol-function 'magnus-codex--notify)
+                   (lambda (_process method &optional _params)
+                     (setq notified method)))
                   ((symbol-function 'magnus-codex--spawn-tui)
                    (lambda (candidate message)
                      (setq spawned (list candidate message)))))
-          (magnus-codex--open-thread process instance "first task")
+          (magnus-codex--initialize process instance "first task")
           (should (equal (magnus-instance-session-id instance)
                          "thread-existing"))
+          (should (equal notified "initialized"))
           (should (eq (car spawned) instance))
           (should (equal (cadr spawned) "first task")))
       (delete-process process))))

--- a/test/magnus-provider-tests.el
+++ b/test/magnus-provider-tests.el
@@ -5,6 +5,26 @@
 (require 'magnus-instances)
 (require 'magnus-provider)
 (require 'magnus-provider-codex)
+(require 'magnus-coord)
+(require 'magnus-health)
+
+(defun magnus-test--codex-process (instance)
+  "Create a live inert App Server stand-in for INSTANCE."
+  (let ((process
+         (make-pipe-process
+          :name (generate-new-buffer-name
+                 (format "magnus-test-%s" (magnus-instance-id instance)))
+          :noquery t)))
+    (process-put process 'magnus-codex-instance instance)
+    (process-put process 'magnus-codex-pending
+                 (make-hash-table :test #'equal))
+    (process-put process 'magnus-codex-approvals
+                 (make-hash-table :test #'equal))
+    (process-put process 'magnus-codex-input-queue nil)
+    (process-put process 'magnus-codex-turn-starting nil)
+    (puthash (magnus-instance-id instance) process
+             magnus-codex--connections)
+    process))
 
 (ert-deftest magnus-provider-legacy-state-defaults-to-claude ()
   (let ((instance (magnus-instances-deserialize
@@ -66,42 +86,163 @@
       (delete-directory directory t))))
 
 (ert-deftest magnus-codex-command-approval-keeps-v2-response-shape ()
-  (let* ((instance (magnus-instances-create "/tmp" "codex-user" 'codex))
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "codex-user" 'codex))
          (request-id 7)
+         (process (magnus-test--codex-process instance))
          sent)
-    (puthash request-id
-             (list :instance instance :process 'fake-process
-                   :method "item/commandExecution/requestApproval")
-             magnus-codex--approvals)
-    (cl-letf (((symbol-function 'magnus-codex--send-object)
-               (lambda (_process object) (setq sent object)))
-              ((symbol-function 'magnus-codex--insert)
-               (lambda (&rest _arguments) nil)))
-      (magnus-codex-respond-approval instance request-id "accept"))
-    (should (equal (alist-get 'result sent)
-                   '((decision . "accept"))))))
+    (unwind-protect
+        (progn
+          (puthash request-id
+                   (list :instance instance :process process
+                         :method "item/commandExecution/requestApproval")
+                   (magnus-codex--approval-table process))
+          (cl-letf (((symbol-function 'magnus-codex--send-object)
+                     (lambda (_process object) (setq sent object)))
+                    ((symbol-function 'magnus-codex--insert)
+                     (lambda (&rest _arguments) nil)))
+            (magnus-codex-respond-approval instance request-id "accept"))
+          (should (equal (alist-get 'result sent)
+                         '((decision . "accept")))))
+      (delete-process process))))
 
 (ert-deftest magnus-codex-permission-approval-requires-profile ()
-  (let* ((instance (magnus-instances-create "/tmp" "codex-user" 'codex))
-         (request-id 8))
-    (puthash request-id
-             (list :instance instance :process 'fake-process
-                   :method "item/permissions/requestApproval")
-             magnus-codex--approvals)
-    (should-error
-     (magnus-codex-respond-approval instance request-id "accept")
-     :type 'user-error)))
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "codex-user" 'codex))
+         (request-id 8)
+         (process (magnus-test--codex-process instance)))
+    (unwind-protect
+        (progn
+          (puthash request-id
+                   (list :instance instance :process process
+                         :method "item/permissions/requestApproval")
+                   (magnus-codex--approval-table process))
+          (should-error
+           (magnus-codex-respond-approval instance request-id "accept")
+           :type 'user-error))
+      (delete-process process))))
 
 (ert-deftest magnus-codex-rejects-unknown-command-approval-decision ()
-  (let* ((instance (magnus-instances-create "/tmp" "codex-user" 'codex))
-         (request-id 9))
-    (puthash request-id
-             (list :instance instance :process 'fake-process
-                   :method "item/fileChange/requestApproval")
-             magnus-codex--approvals)
-    (should-error
-     (magnus-codex-respond-approval instance request-id "approve-everything")
-     :type 'user-error)))
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "codex-user" 'codex))
+         (request-id 9)
+         (process (magnus-test--codex-process instance)))
+    (unwind-protect
+        (progn
+          (puthash request-id
+                   (list :instance instance :process process
+                         :method "item/fileChange/requestApproval")
+                   (magnus-codex--approval-table process))
+          (should-error
+           (magnus-codex-respond-approval
+            instance request-id "approve-everything")
+           :type 'user-error))
+      (delete-process process))))
+
+(ert-deftest magnus-codex-approval-ids-are-scoped-per-process ()
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (first (magnus-instances-create "/tmp" "first-codex" 'codex))
+         (second (magnus-instances-create "/tmp" "second-codex" 'codex))
+         (first-process (magnus-test--codex-process first))
+         (second-process (magnus-test--codex-process second))
+         sent)
+    (unwind-protect
+        (cl-letf (((symbol-function 'magnus-codex--insert)
+                   (lambda (&rest _arguments) nil))
+                  ((symbol-function 'magnus-codex--send-object)
+                   (lambda (process object)
+                     (push (cons process object) sent))))
+          (magnus-codex--handle-server-request
+           first-process 3 "item/commandExecution/requestApproval"
+           '((command . "git status")))
+          (magnus-codex--handle-server-request
+           second-process 3 "item/fileChange/requestApproval"
+           '((reason . "edit file")))
+          (should (= 1 (hash-table-count
+                        (magnus-codex--approval-table first-process))))
+          (should (= 1 (hash-table-count
+                        (magnus-codex--approval-table second-process))))
+          (magnus-codex-respond-approval first 3 "accept")
+          (should (= 0 (hash-table-count
+                        (magnus-codex--approval-table first-process))))
+          (should (= 1 (hash-table-count
+                        (magnus-codex--approval-table second-process))))
+          (magnus-codex-respond-approval second 3 "decline")
+          (should (= 0 (hash-table-count
+                        (magnus-codex--approval-table second-process))))
+          (should (= 2 (length sent))))
+      (delete-process first-process)
+      (delete-process second-process))))
+
+(ert-deftest magnus-codex-approval-summary-accepts-argv-arrays ()
+  (should
+   (equal
+    (magnus-codex--approval-summary
+     '((command . ("git" "status" "--short")) (cwd . "/tmp")))
+    "git status --short\ncwd: /tmp")))
+
+(ert-deftest magnus-codex-active-turn-messages-queue-by-default ()
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (magnus-codex--active-turns (make-hash-table :test #'equal))
+         (magnus-codex-active-turn-delivery 'queue)
+         (instance (magnus-instances-create "/tmp" "queued-codex" 'codex))
+         (process (magnus-test--codex-process instance))
+         requests)
+    (magnus-instances-update instance :session-id "thread-1")
+    (puthash (magnus-instance-id instance) "turn-1"
+             magnus-codex--active-turns)
+    (unwind-protect
+        (cl-letf (((symbol-function 'magnus-codex--insert)
+                   (lambda (&rest _arguments) nil))
+                  ((symbol-function 'magnus-codex--request)
+                   (lambda (_process method params _callback)
+                     (push (cons method params) requests)
+                     1)))
+          (magnus-codex-send instance "read this next")
+          (should-not requests)
+          (should (equal (process-get process 'magnus-codex-input-queue)
+                         '("read this next")))
+          (magnus-codex--handle-notification
+           process "turn/completed" '((turn . ((id . "turn-1")))))
+          (should (equal (caar requests) "turn/start"))
+          (should-not (process-get process 'magnus-codex-input-queue)))
+      (delete-process process))))
+
+(ert-deftest magnus-coord-stopped-agent-nudge-is-logged-not-signaled ()
+  (let* ((directory (make-temp-file "magnus-stopped-nudge-" t))
+         (instance (magnus-instances-create directory "stopped-codex" 'codex))
+         (magnus-coord-nudge-debounce nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'magnus-process-running-p)
+                   (lambda (_instance) nil)))
+          (should-not
+           (magnus-coord-nudge-agent
+            instance "Please tell @bold-wren later" "Magnus"))
+          (let ((log (with-temp-buffer
+                       (insert-file-contents
+                        (expand-file-name ".magnus-coord.md" directory))
+                       (buffer-string))))
+            (should (string-match-p "Undelivered nudge" log))
+            (should (string-match-p "(at) bold-wren" log))))
+      (delete-directory directory t))))
+
+(ert-deftest magnus-health-check-supports-codex-output-buffers ()
+  (let* ((magnus-codex--connections (make-hash-table :test #'equal))
+         (magnus-health--state (make-hash-table :test #'equal))
+         (instance (magnus-instances-create "/tmp" "healthy-codex" 'codex))
+         (process (magnus-test--codex-process instance))
+         (buffer (generate-new-buffer " *healthy-codex*")))
+    (magnus-instances-update instance :status 'running :buffer buffer)
+    (with-current-buffer buffer
+      (insert "streamed Codex output"))
+    (unwind-protect
+        (cl-letf (((symbol-function 'magnus-process-running-p)
+                   (lambda (candidate)
+                     (magnus-provider-call candidate 'running-p))))
+          (magnus-health--check-instance instance)
+          (should (eq (magnus-health-get instance) 'ok)))
+      (kill-buffer buffer)
+      (delete-process process))))
 
 (provide 'magnus-provider-tests)
 ;;; magnus-provider-tests.el ends here


### PR DESCRIPTION
## Summary

- introduce a provider abstraction while keeping Claude as the default
- run opt-in Codex agents in the full native TUI inside vterm
- make the TUI the sole session owner; no app-server daemon, proxy, or WebSocket observer
- capture fresh Codex session IDs by exact onboarding-prompt correlation for concurrent-safe resurrection
- render provider-aware thinking traces from Claude and Codex JSONL records
- adapt Magnus identity, memory, coordination, and debrief prompts for Codex
- serialize automated TUI delivery and guard stale terminal generations

## Backward compatibility

Existing serialized sessions without a provider continue to deserialize as Claude. The established Claude workflow and trace schema remain unchanged, and Codex support stays lazy-loaded and opt-in.

## Trace privacy

Codex traces render visible user and agent events, including explicit `[thinking]` engineering journals. Duplicated response items and encrypted internal reasoning are deliberately ignored.

## Verification

- make test (29 tests)
- make lint
- make lint-compile
- real wise-deer rollout parsing and rendering
- end-to-end `magnus-process-trace` invocation in running Emacs
- adversarial review of session identity, timer ownership, JSONL partial writes, trim snapshots, stale generations, and Emacs 28 API compatibility

Authored by Sol.