### PR TITLE
docs: polish the README problem framing and screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ But this creates problems:
 - **File conflicts**: Agents might edit the same files
 - **Context sharing**: How do agents know what others are doing?
 - **Permission chaos**: Multiple agents asking for input at once
-- How to get a different model to review the work produced by a given model?
+- **Independent review**: How do you get one model to review another model's work?
 
 Magnus solves all of this.
 


### PR DESCRIPTION
## Summary

- restore the name-and-description pattern in the Why Magnus problem list
- frame cross-model review as the independent-review problem
- show two real Claude Code agents working side by side in their own vterm buffers
- keep the Magnus status screenshot as the coordination overview

## Validation

- make lint
- README local-link check
- screenshot: 1800x1017 WebP, 159 KB